### PR TITLE
Fix hardcoded thrift path

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -181,7 +181,7 @@ subprojects {
         thriftFiles.collect {
             ext.file = relativePath(it)
             exec {
-                executable = '/opt/thrift-0.9.1/bin/thrift'
+                executable = 'thrift'
                 args = ['--gen', 'java:hashcode,private-members', '-o', thriftOutputDir, ext.file]
             }
         }


### PR DESCRIPTION
Hi,

I'm starting to play around with the code at McKay-Brothers.
Just had to fix the hardcoded thrift path in gradle build file.

Can this be changed, thrift shall be in the PATH anyway, no ?
