### PR TITLE
Fix GTSHelper.quicksortByLocation

### DIFF
--- a/warp10/src/main/java/io/warp10/continuum/gts/GTSHelper.java
+++ b/warp10/src/main/java/io/warp10/continuum/gts/GTSHelper.java
@@ -567,10 +567,10 @@ public class GTSHelper {
     
     // Recursion
     if (low < j) {
-      quicksortByValue(gts, low, j, reversed);
+      quicksortByLocation(gts, low, j, reversed);
     }
     if (i < high) {   
-      quicksortByValue(gts, i, high, reversed);
+      quicksortByLocation(gts, i, high, reversed);
     }
   }
 


### PR DESCRIPTION

Hi,

Is GTSHelper.quicksortByLocation still used it doesn't seem to be called ?