### PR TITLE
Add ->ITERABLE, ITERABLE-> and CONCAT operations

### DIFF
--- a/warp10/src/main/java/io/warp10/script/WarpScriptLib.java
+++ b/warp10/src/main/java/io/warp10/script/WarpScriptLib.java
@@ -305,6 +305,9 @@ public class WarpScriptLib {
     functions.put("STU", new STU("STU"));
     functions.put("UNIXTIMEEND", new UNIXTIMEEND("UNIXTIMEEND"));
     functions.put("UNIXTIMEALIGN", new UNIXTIMEALIGN("UNIXTIMEALIGN"));
+    functions.put("CONCAT", new CONCAT("CONCAT"));
+    functions.put("->ITERABLE", new TOITERABLE("->ITERABLE"));
+    functions.put("ITERABLE->", new ITERABLETO("ITERABLE->"));
     functions.put("APPEND", new APPEND("APPEND"));                      // doc/einstein/function_APPEND        Example done    Refactored
     functions.put("STORE", new STORE("STORE"));                         // doc/einstein/function_STORE         Example done    Refactored
     functions.put("CSTORE", new CSTORE("CSTORE"));

--- a/warp10/src/main/java/io/warp10/script/functions/CONCAT.java
+++ b/warp10/src/main/java/io/warp10/script/functions/CONCAT.java
@@ -1,0 +1,36 @@
+
+package io.warp10.script.functions;
+
+import org.python.google.common.collect.Iterables;
+
+import io.warp10.script.NamedWarpScriptFunction;
+import io.warp10.script.WarpScriptException;
+import io.warp10.script.WarpScriptStack;
+import io.warp10.script.WarpScriptStackFunction;
+
+/**
+ * Return the concatenation of two ITERABLE
+ * This is a constant time operation similar to APPEND,
+ * but it will only work on ITERABLE.
+ * @param element A List
+ */
+public class CONCAT extends NamedWarpScriptFunction implements WarpScriptStackFunction  {
+  public CONCAT(String name) {
+    super(name);
+  }
+
+  @Override
+  public Object apply(WarpScriptStack stack) throws WarpScriptException {
+    Object top = stack.pop();
+    Object undertop = stack.pop();
+    if ((!(top instanceof Iterable)) ||
+        (!(undertop instanceof Iterable))) {
+      throw new WarpScriptException(getName() + " expects two list on top of the stack.");
+    }
+
+    Iterable concatenated = Iterables.concat((Iterable) undertop, 
+                                             (Iterable) top);
+    stack.push(concatenated);
+    return stack;
+  }
+}

--- a/warp10/src/main/java/io/warp10/script/functions/ITERABLETO.java
+++ b/warp10/src/main/java/io/warp10/script/functions/ITERABLETO.java
@@ -1,0 +1,33 @@
+
+package io.warp10.script.functions;
+
+import io.warp10.script.NamedWarpScriptFunction;
+import io.warp10.script.WarpScriptStackFunction;
+import io.warp10.script.WarpScriptException;
+import io.warp10.script.WarpScriptStack;
+
+import java.util.List;
+
+import com.google.common.collect.Lists;
+
+/**
+ * Make a copy of an Iterable and transform it to a List.
+ * @param element A List
+ */
+public class ITERABLETO extends NamedWarpScriptFunction implements WarpScriptStackFunction {
+  
+  public ITERABLETO(String name) {
+    super(name);
+  }
+
+  @Override
+  public Object apply(WarpScriptStack stack) throws WarpScriptException {
+    Object iterable = stack.pop();
+    if (!(iterable instanceof Iterable)) {
+      throw new WarpScriptException(getName() + " expects an Iterable on top of the stack.");
+    }
+    List list = Lists.newArrayList((Iterable) iterable);
+    stack.push(list);
+    return stack;
+  }
+}

--- a/warp10/src/main/java/io/warp10/script/functions/TOITERABLE.java
+++ b/warp10/src/main/java/io/warp10/script/functions/TOITERABLE.java
@@ -1,0 +1,30 @@
+
+package io.warp10.script.functions;
+
+import io.warp10.script.NamedWarpScriptFunction;
+import io.warp10.script.WarpScriptStackFunction;
+import io.warp10.script.WarpScriptException;
+import io.warp10.script.WarpScriptStack;
+
+import java.util.List;
+
+/**
+ * Make an Iterable List from a List
+ * @param element A List
+ */
+public class TOITERABLE extends NamedWarpScriptFunction implements WarpScriptStackFunction {
+  
+  public TOITERABLE(String name) {
+    super(name);
+  }
+
+  @Override
+  public Object apply(WarpScriptStack stack) throws WarpScriptException {
+    Object list = stack.pop();
+    if (!(list instanceof List)) {
+      throw new WarpScriptException(getName() + " expects a list on top of the stack.");
+    }
+    stack.push((Iterable) list);
+    return stack;
+  }
+}


### PR DESCRIPTION
 - allow to handle iterable in WarpScript
   by adding ->ITERABLE (TOITERABLE) and ITERABLE-> (ITERABLETO) conversion operations.
 - add CONCAT function that concatenate in constant time two ITERABLE converted list.