### PR TITLE
Change type of maxdepth and maxsymbol to long

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,5 +1,17 @@
 # WARP 10 IDE Setup & Build  
 
+## Install Thrift on MAC OS
+The current version of thrift used by Warp10 is thrift 0.9.1. Download the tar.gz on the official Apache Thrift page (http://archive.apache.org/dist/thrift/0.9.1/). Then execute the following commands: 
+
+	./configure --without-python --prefix=/opt/thrift CPPFLAGS='-I/usr/local/opt/openssl/include'
+	make
+
+Make may raise Errors and warning, do not care about it and exec: 
+
+	sudo make install
+	
+Then add "/opt/thrift/bin" to your path before follwing the next steps
+
 ## IDE Setup
 
 ### Eclipse Configuration
@@ -36,7 +48,7 @@ Activate MavenLocal() repository (uncomment it in the global repositories defini
     gradle token:install
     
 #### 3. updates Eclipse External Dependencies
-Warp10 Context Menu / Gradle / Refresh Gradle Project  
+Warp10 Context Menu / Gradle / Refresh Gradle Project
 
 ## RELEASE Procedure
 
@@ -59,3 +71,4 @@ Build Warp10 in the order bellow
     gradle crypto:clean crypto:bintrayUpload   (if updated)
     gradle token:clean  token:bintrayUpload    (if updated)
     gradle warp10:clean warp10:bintrayUpload
+    

--- a/warp10/src/main/java/io/warp10/script/MemoryWarpScriptStack.java
+++ b/warp10/src/main/java/io/warp10/script/MemoryWarpScriptStack.java
@@ -56,7 +56,7 @@ public class MemoryWarpScriptStack implements WarpScriptStack, Progressable {
   /**
    * Default maximum depth of the stack
    */
-  private int maxdepth = 0;
+  private long maxdepth = 0L;
 
   /**
    * Maximum number of operations for this stack
@@ -66,7 +66,7 @@ public class MemoryWarpScriptStack implements WarpScriptStack, Progressable {
   /**
    * Maximum number of entries in the symbol table
    */
-  private int maxsymbols = 0;
+  private long maxsymbols = 0L;
   
   /**
    * Maximum recursion level
@@ -169,8 +169,8 @@ public class MemoryWarpScriptStack implements WarpScriptStack, Progressable {
     setAttribute(WarpScriptStack.ATTRIBUTE_LOOP_MAXDURATION, Long.parseLong(properties.getProperty(Configuration.WARPSCRIPT_MAX_LOOP_DURATION, Long.toString(WarpScriptStack.DEFAULT_MAX_LOOP_DURATION))));
     setAttribute(WarpScriptStack.ATTRIBUTE_RECURSION_MAXDEPTH, Long.parseLong(properties.getProperty(Configuration.WARPSCRIPT_MAX_RECURSION, Long.toString(WarpScriptStack.DEFAULT_MAX_RECURSION_LEVEL))));
     setAttribute(WarpScriptStack.ATTRIBUTE_MAX_OPS, Long.parseLong(properties.getProperty(Configuration.WARPSCRIPT_MAX_OPS, Long.toString(WarpScriptStack.DEFAULT_MAX_OPS))));
-    setAttribute(WarpScriptStack.ATTRIBUTE_MAX_SYMBOLS, Integer.parseInt(properties.getProperty(Configuration.WARPSCRIPT_MAX_SYMBOLS, Integer.toString(WarpScriptStack.DEFAULT_MAX_SYMBOLS))));
-    setAttribute(WarpScriptStack.ATTRIBUTE_MAX_DEPTH, Integer.parseInt(properties.getProperty(Configuration.WARPSCRIPT_MAX_DEPTH, Integer.toString(WarpScriptStack.DEFAULT_MAX_DEPTH))));
+    setAttribute(WarpScriptStack.ATTRIBUTE_MAX_SYMBOLS, Integer.parseLong(properties.getProperty(Configuration.WARPSCRIPT_MAX_SYMBOLS, Integer.toString(WarpScriptStack.DEFAULT_MAX_SYMBOLS))));
+    setAttribute(WarpScriptStack.ATTRIBUTE_MAX_DEPTH, Integer.parseLong(properties.getProperty(Configuration.WARPSCRIPT_MAX_DEPTH, Integer.toString(WarpScriptStack.DEFAULT_MAX_DEPTH))));
     setAttribute(WarpScriptStack.ATTRIBUTE_MAX_WEBCALLS, new AtomicLong(Long.parseLong(properties.getProperty(Configuration.WARPSCRIPT_MAX_WEBCALLS, Integer.toString(WarpScriptStack.DEFAULT_MAX_WEBCALLS)))));
     setAttribute(WarpScriptStack.ATTRIBUTE_MAX_BUCKETS, Long.parseLong(properties.getProperty(Configuration.WARPSCRIPT_MAX_BUCKETS, Integer.toString(WarpScriptStack.DEFAULT_MAX_BUCKETS))));
     setAttribute(WarpScriptStack.ATTRIBUTE_MAX_PIXELS, Long.parseLong(properties.getProperty(Configuration.WARPSCRIPT_MAX_PIXELS, Long.toString(WarpScriptStack.DEFAULT_MAX_PIXELS))));
@@ -185,9 +185,9 @@ public class MemoryWarpScriptStack implements WarpScriptStack, Progressable {
     
     setAttribute(WarpScriptStack.ATTRIBUTE_LOOP_MAXDURATION_HARD, Long.parseLong(properties.getProperty(Configuration.WARPSCRIPT_MAX_LOOP_DURATION_HARD, Long.toString(WarpScriptStack.DEFAULT_MAX_LOOP_DURATION))));
     setAttribute(WarpScriptStack.ATTRIBUTE_RECURSION_MAXDEPTH_HARD, Long.parseLong(properties.getProperty(Configuration.WARPSCRIPT_MAX_RECURSION_HARD, Long.toString(WarpScriptStack.DEFAULT_MAX_RECURSION_LEVEL))));
-    setAttribute(WarpScriptStack.ATTRIBUTE_MAX_DEPTH_HARD, Integer.parseInt(properties.getProperty(Configuration.WARPSCRIPT_MAX_DEPTH_HARD, Integer.toString(WarpScriptStack.DEFAULT_MAX_DEPTH))));
+    setAttribute(WarpScriptStack.ATTRIBUTE_MAX_DEPTH_HARD, Integer.parseLong(properties.getProperty(Configuration.WARPSCRIPT_MAX_DEPTH_HARD, Integer.toString(WarpScriptStack.DEFAULT_MAX_DEPTH))));
     setAttribute(WarpScriptStack.ATTRIBUTE_MAX_OPS_HARD, Long.parseLong(properties.getProperty(Configuration.WARPSCRIPT_MAX_OPS_HARD, Long.toString(WarpScriptStack.DEFAULT_MAX_OPS))));
-    setAttribute(WarpScriptStack.ATTRIBUTE_MAX_SYMBOLS_HARD, Integer.parseInt(properties.getProperty(Configuration.WARPSCRIPT_MAX_SYMBOLS_HARD, Integer.toString(WarpScriptStack.DEFAULT_MAX_SYMBOLS))));
+    setAttribute(WarpScriptStack.ATTRIBUTE_MAX_SYMBOLS_HARD, Integer.parseLong(properties.getProperty(Configuration.WARPSCRIPT_MAX_SYMBOLS_HARD, Integer.toString(WarpScriptStack.DEFAULT_MAX_SYMBOLS))));
     setAttribute(WarpScriptStack.ATTRIBUTE_MAX_BUCKETS_HARD, Long.parseLong(properties.getProperty(Configuration.WARPSCRIPT_MAX_BUCKETS_HARD, Integer.toString(WarpScriptStack.DEFAULT_MAX_BUCKETS))));
     setAttribute(WarpScriptStack.ATTRIBUTE_MAX_PIXELS_HARD, Long.parseLong(properties.getProperty(Configuration.WARPSCRIPT_MAX_PIXELS_HARD, Long.toString(WarpScriptStack.DEFAULT_MAX_PIXELS))));
     setAttribute(WarpScriptStack.ATTRIBUTE_FETCH_LIMIT_HARD, Long.parseLong(properties.getProperty(Configuration.WARPSCRIPT_MAX_FETCH_HARD, Long.toString(WarpScriptStack.DEFAULT_FETCH_LIMIT))));
@@ -1010,13 +1010,13 @@ public class MemoryWarpScriptStack implements WarpScriptStack, Progressable {
     }
     
     if (WarpScriptStack.ATTRIBUTE_MAX_DEPTH.equals(key)) {
-      this.maxdepth = ((Number) value).intValue();
+      this.maxdepth = ((Number) value).longValue();
     } else if (WarpScriptStack.ATTRIBUTE_MAX_OPS.equals(key)) {
       this.maxops = ((Number) value).longValue();
     } else if (WarpScriptStack.ATTRIBUTE_RECURSION_MAXDEPTH.equals(key)) {
-      this.maxrecurse = ((Number) value).intValue();
+      this.maxrecurse = ((Number) value).longValue();
     } else if (WarpScriptStack.ATTRIBUTE_MAX_SYMBOLS.equals(key)) {
-      this.maxsymbols = ((Number) value).intValue();
+      this.maxsymbols = ((Number) value).longValue();
     } else if (WarpScriptStack.ATTRIBUTE_OPS.equals(key)) {
       this.currentops = ((Number) value).longValue();
     } else if (WarpScriptStack.ATTRIBUTE_HADOOP_PROGRESSABLE.equals(key)) {

--- a/warp10/src/main/java/io/warp10/script/MemoryWarpScriptStack.java
+++ b/warp10/src/main/java/io/warp10/script/MemoryWarpScriptStack.java
@@ -169,8 +169,8 @@ public class MemoryWarpScriptStack implements WarpScriptStack, Progressable {
     setAttribute(WarpScriptStack.ATTRIBUTE_LOOP_MAXDURATION, Long.parseLong(properties.getProperty(Configuration.WARPSCRIPT_MAX_LOOP_DURATION, Long.toString(WarpScriptStack.DEFAULT_MAX_LOOP_DURATION))));
     setAttribute(WarpScriptStack.ATTRIBUTE_RECURSION_MAXDEPTH, Long.parseLong(properties.getProperty(Configuration.WARPSCRIPT_MAX_RECURSION, Long.toString(WarpScriptStack.DEFAULT_MAX_RECURSION_LEVEL))));
     setAttribute(WarpScriptStack.ATTRIBUTE_MAX_OPS, Long.parseLong(properties.getProperty(Configuration.WARPSCRIPT_MAX_OPS, Long.toString(WarpScriptStack.DEFAULT_MAX_OPS))));
-    setAttribute(WarpScriptStack.ATTRIBUTE_MAX_SYMBOLS, Integer.parseLong(properties.getProperty(Configuration.WARPSCRIPT_MAX_SYMBOLS, Integer.toString(WarpScriptStack.DEFAULT_MAX_SYMBOLS))));
-    setAttribute(WarpScriptStack.ATTRIBUTE_MAX_DEPTH, Integer.parseLong(properties.getProperty(Configuration.WARPSCRIPT_MAX_DEPTH, Integer.toString(WarpScriptStack.DEFAULT_MAX_DEPTH))));
+    setAttribute(WarpScriptStack.ATTRIBUTE_MAX_SYMBOLS, Long.parseLong(properties.getProperty(Configuration.WARPSCRIPT_MAX_SYMBOLS, Integer.toString(WarpScriptStack.DEFAULT_MAX_SYMBOLS))));
+    setAttribute(WarpScriptStack.ATTRIBUTE_MAX_DEPTH, Long.parseLong(properties.getProperty(Configuration.WARPSCRIPT_MAX_DEPTH, Integer.toString(WarpScriptStack.DEFAULT_MAX_DEPTH))));
     setAttribute(WarpScriptStack.ATTRIBUTE_MAX_WEBCALLS, new AtomicLong(Long.parseLong(properties.getProperty(Configuration.WARPSCRIPT_MAX_WEBCALLS, Integer.toString(WarpScriptStack.DEFAULT_MAX_WEBCALLS)))));
     setAttribute(WarpScriptStack.ATTRIBUTE_MAX_BUCKETS, Long.parseLong(properties.getProperty(Configuration.WARPSCRIPT_MAX_BUCKETS, Integer.toString(WarpScriptStack.DEFAULT_MAX_BUCKETS))));
     setAttribute(WarpScriptStack.ATTRIBUTE_MAX_PIXELS, Long.parseLong(properties.getProperty(Configuration.WARPSCRIPT_MAX_PIXELS, Long.toString(WarpScriptStack.DEFAULT_MAX_PIXELS))));
@@ -185,9 +185,9 @@ public class MemoryWarpScriptStack implements WarpScriptStack, Progressable {
     
     setAttribute(WarpScriptStack.ATTRIBUTE_LOOP_MAXDURATION_HARD, Long.parseLong(properties.getProperty(Configuration.WARPSCRIPT_MAX_LOOP_DURATION_HARD, Long.toString(WarpScriptStack.DEFAULT_MAX_LOOP_DURATION))));
     setAttribute(WarpScriptStack.ATTRIBUTE_RECURSION_MAXDEPTH_HARD, Long.parseLong(properties.getProperty(Configuration.WARPSCRIPT_MAX_RECURSION_HARD, Long.toString(WarpScriptStack.DEFAULT_MAX_RECURSION_LEVEL))));
-    setAttribute(WarpScriptStack.ATTRIBUTE_MAX_DEPTH_HARD, Integer.parseLong(properties.getProperty(Configuration.WARPSCRIPT_MAX_DEPTH_HARD, Integer.toString(WarpScriptStack.DEFAULT_MAX_DEPTH))));
+    setAttribute(WarpScriptStack.ATTRIBUTE_MAX_DEPTH_HARD, Long.parseLong(properties.getProperty(Configuration.WARPSCRIPT_MAX_DEPTH_HARD, Integer.toString(WarpScriptStack.DEFAULT_MAX_DEPTH))));
     setAttribute(WarpScriptStack.ATTRIBUTE_MAX_OPS_HARD, Long.parseLong(properties.getProperty(Configuration.WARPSCRIPT_MAX_OPS_HARD, Long.toString(WarpScriptStack.DEFAULT_MAX_OPS))));
-    setAttribute(WarpScriptStack.ATTRIBUTE_MAX_SYMBOLS_HARD, Integer.parseLong(properties.getProperty(Configuration.WARPSCRIPT_MAX_SYMBOLS_HARD, Integer.toString(WarpScriptStack.DEFAULT_MAX_SYMBOLS))));
+    setAttribute(WarpScriptStack.ATTRIBUTE_MAX_SYMBOLS_HARD, Long.parseLong(properties.getProperty(Configuration.WARPSCRIPT_MAX_SYMBOLS_HARD, Integer.toString(WarpScriptStack.DEFAULT_MAX_SYMBOLS))));
     setAttribute(WarpScriptStack.ATTRIBUTE_MAX_BUCKETS_HARD, Long.parseLong(properties.getProperty(Configuration.WARPSCRIPT_MAX_BUCKETS_HARD, Integer.toString(WarpScriptStack.DEFAULT_MAX_BUCKETS))));
     setAttribute(WarpScriptStack.ATTRIBUTE_MAX_PIXELS_HARD, Long.parseLong(properties.getProperty(Configuration.WARPSCRIPT_MAX_PIXELS_HARD, Long.toString(WarpScriptStack.DEFAULT_MAX_PIXELS))));
     setAttribute(WarpScriptStack.ATTRIBUTE_FETCH_LIMIT_HARD, Long.parseLong(properties.getProperty(Configuration.WARPSCRIPT_MAX_FETCH_HARD, Long.toString(WarpScriptStack.DEFAULT_FETCH_LIMIT))));


### PR DESCRIPTION
Pull request to solve [issue 21](https://github.com/cityzendata/warp10-platform/issues/21). Change type of maxdepth and maxsymbols to long to avoid an exception when using MAXDEPTH and MAXSYMBOL in Warpscript.