### PR TITLE
Added fine grained metrics to track the number of points deleted per owner+application

### DIFF
--- a/warp10/src/main/java/io/warp10/Revision.java
+++ b/warp10/src/main/java/io/warp10/Revision.java
@@ -1,5 +1,5 @@
 package io.warp10;
 
 public class Revision {
-  public static final String REVISION = "1.0.1-137-g920718e";
+  public static final String REVISION = "1.0.0";
 }

--- a/warp10/src/main/java/io/warp10/Revision.java
+++ b/warp10/src/main/java/io/warp10/Revision.java
@@ -1,5 +1,5 @@
 package io.warp10;
 
 public class Revision {
-  public static final String REVISION = "1.0.0";
+  public static final String REVISION = "1.0.1-137-g920718e";
 }

--- a/warp10/src/main/java/io/warp10/continuum/ingress/Ingress.java
+++ b/warp10/src/main/java/io/warp10/continuum/ingress/Ingress.java
@@ -1101,7 +1101,7 @@ public class Ingress extends AbstractHandler implements Runnable {
         while(iterator.hasNext()) {
           Metadata metadata = iterator.next();
         
-          pushDeleteMessage(start, end, minage, metadata);
+          pushDeleteMessage(start, end, minage, metadata, writeToken);
           
           if (Long.MAX_VALUE == end && Long.MIN_VALUE == start && 0 == minage) {
             completeDeletion = true;
@@ -1134,7 +1134,7 @@ public class Ingress extends AbstractHandler implements Runnable {
       }
     } finally {
       // Flush delete messages
-      pushDeleteMessage(0L,0L,0L,null);
+      pushDeleteMessage(0L,0L,0L,null, writeToken);
       if (completeDeletion) {
         pushMetadataMessage(null, null);
       }
@@ -1453,8 +1453,9 @@ public class Ingress extends AbstractHandler implements Runnable {
    * @param start Start timestamp for deletion
    * @param end End timestamp for deletion
    * @param metadata Metadata of the GTS to delete
+   * @param writeToken Write token making deletion request
    */
-  private void pushDeleteMessage(long start, long end, long minage, Metadata metadata) throws IOException {    
+  private void pushDeleteMessage(long start, long end, long minage, Metadata metadata, WriteToken writeToken) throws IOException {
     if (null != metadata) {
       KafkaDataMessage msg = new KafkaDataMessage();
       msg.setType(KafkaDataMessageType.DELETE);
@@ -1463,6 +1464,7 @@ public class Ingress extends AbstractHandler implements Runnable {
       msg.setDeletionMinAge(minage);
       msg.setClassId(metadata.getClassId());
       msg.setLabelsId(metadata.getLabelsId());
+      msg.setWriteToken(writeToken);
 
       sendDataMessage(msg);
     } else {

--- a/warp10/src/main/java/io/warp10/continuum/sensision/SensisionConstants.java
+++ b/warp10/src/main/java/io/warp10/continuum/sensision/SensisionConstants.java
@@ -25,7 +25,7 @@ public class SensisionConstants {
       Sensision.setInstance("warp");
     }
   }
-  
+
   //
   // Classes
   //
@@ -499,6 +499,11 @@ public class SensisionConstants {
    * Number of datapoints deleted by 'Store'
    */
   public static final String SENSISION_CLASS_CONTINUUM_STORE_HBASE_DELETE_DATAPOINTS = "warp.store.hbase.delete.datapoints";
+
+  /**
+   * Number of datapoints deleted by 'Store' per owner and application
+   */
+  public static final String SENSISION_CLASS_CONTINUUM_STORE_HBASE_DELETE_DATAPOINTS_PEROWNER = "warp.store.hbase.delete.datapoints.perowner";
 
   /**
    * Number of results retrieved from scanners by HBaseStoreClient

--- a/warp10/src/main/thrift/io_warp10_continuum_store_thrift_data.thrift
+++ b/warp10/src/main/thrift/io_warp10_continuum_store_thrift_data.thrift
@@ -1,5 +1,6 @@
-namespace java io.warp10.continuum.store.thrift.data
+include "../../../../token/src/main/thrift/io_warp10_quasar_token_thrift_data.thrift"
 
+namespace java io.warp10.continuum.store.thrift.data
 /**
  * Metadata describing a Geo Time Serie
  */ 
@@ -95,6 +96,11 @@ struct KafkaDataMessage {
    * Minimum age of cells to delete (in ms)
    */
   8: optional i64 deletionMinAge,
+
+  /**
+   * Optional write token to log metrics in deletion requests
+   */
+  9: optional io_warp10_quasar_token_thrift_data.WriteToken writeToken,
 }
 
 /**


### PR DESCRIPTION
For accounting purposes, I need to have a fine grained visibility on the number of points deleted by a particular user. This change add the write token to Kafka delete messages so that we can report in Sensision the count of deleted points associated to the owner (and app if present)