### PR TITLE
Added detailed deletion metrics

### DIFF
--- a/warp10/src/main/java/io/warp10/continuum/Configuration.java
+++ b/warp10/src/main/java/io/warp10/continuum/Configuration.java
@@ -356,7 +356,12 @@ public class Configuration {
    * Identification of Ingress Metadata Update endpoint source
    */
   public static final String INGRESS_METADATA_UPDATE_ENDPOINT = "ingress.metadata.update";
-  
+
+  /**
+   * Do we send Metadata in the Kafka message for delete operations?
+   */
+  public static final String INGRESS_DELETE_METADATA_INCLUDE = "ingress.delete.metadata.include";
+
   /**
    * Host onto which the ingress server should listen
    */

--- a/warp10/src/main/java/io/warp10/continuum/ingress/Ingress.java
+++ b/warp10/src/main/java/io/warp10/continuum/ingress/Ingress.java
@@ -65,8 +65,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
-import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.LockSupport;
@@ -250,6 +248,8 @@ public class Ingress extends AbstractHandler implements Runnable {
   private final byte[] aesDataKey;
   private final long[] siphashDataKey;
 
+  private final boolean sendMetadataOnDelete;
+
   private final KafkaSynchronizedConsumerPool  pool;
   
   public Ingress(KeyStore keystore, Properties props) {
@@ -309,7 +309,9 @@ public class Ingress extends AbstractHandler implements Runnable {
     
     this.aesDataKey = this.keystore.getKey(KeyStore.AES_KAFKA_DATA);
     this.siphashDataKey = SipHashInline.getKey(this.keystore.getKey(KeyStore.SIPHASH_KAFKA_DATA));    
-    
+
+    this.sendMetadataOnDelete = Boolean.parseBoolean(props.getProperty(Configuration.INGRESS_DELETE_METADATA_INCLUDE, "true"));
+
     //
     // Prepare meta, data and delete producers
     //
@@ -1463,6 +1465,10 @@ public class Ingress extends AbstractHandler implements Runnable {
       msg.setDeletionMinAge(minage);
       msg.setClassId(metadata.getClassId());
       msg.setLabelsId(metadata.getLabelsId());
+
+      if (this.sendMetadataOnDelete) {
+        msg.setMetadata(metadata);
+      }
 
       sendDataMessage(msg);
     } else {

--- a/warp10/src/main/java/io/warp10/continuum/ingress/Ingress.java
+++ b/warp10/src/main/java/io/warp10/continuum/ingress/Ingress.java
@@ -310,7 +310,7 @@ public class Ingress extends AbstractHandler implements Runnable {
     this.aesDataKey = this.keystore.getKey(KeyStore.AES_KAFKA_DATA);
     this.siphashDataKey = SipHashInline.getKey(this.keystore.getKey(KeyStore.SIPHASH_KAFKA_DATA));    
 
-    this.sendMetadataOnDelete = Boolean.parseBoolean(props.getProperty(Configuration.INGRESS_DELETE_METADATA_INCLUDE, "true"));
+    this.sendMetadataOnDelete = Boolean.parseBoolean(props.getProperty(Configuration.INGRESS_DELETE_METADATA_INCLUDE, "false"));
 
     //
     // Prepare meta, data and delete producers

--- a/warp10/src/main/java/io/warp10/continuum/sensision/SensisionConstants.java
+++ b/warp10/src/main/java/io/warp10/continuum/sensision/SensisionConstants.java
@@ -316,6 +316,11 @@ public class SensisionConstants {
   public static final String SENSISION_CLASS_CONTINUUM_STANDALONE_DELETE_DATAPOINTS = "warp.standalone.delete.datapoints";
 
   /**
+   * Number of datapoints deleted by 'standalone' delete per owner and application
+   */
+  public static final String SENSISION_CLASS_CONTINUUM_STANDALONE_DELETE_DATAPOINTS_PEROWNER = "warp.standalone.delete.datapoints.perowner";
+
+  /**
    * Number of GTS deleted by 'standalone' delete
    */
   public static final String SENSISION_CLASS_CONTINUUM_STANDALONE_DELETE_GTS = "warp.standalone.delete.gts";
@@ -499,6 +504,11 @@ public class SensisionConstants {
    * Number of datapoints deleted by 'Store'
    */
   public static final String SENSISION_CLASS_CONTINUUM_STORE_HBASE_DELETE_DATAPOINTS = "warp.store.hbase.delete.datapoints";
+
+  /**
+   * Number of datapoints deleted by 'Store' per owner and application
+   */
+  public static final String SENSISION_CLASS_CONTINUUM_STORE_HBASE_DELETE_DATAPOINTS_PEROWNER = "warp.store.hbase.delete.datapoints.perowner";
 
   /**
    * Number of results retrieved from scanners by HBaseStoreClient

--- a/warp10/src/main/java/io/warp10/continuum/sensision/SensisionConstants.java
+++ b/warp10/src/main/java/io/warp10/continuum/sensision/SensisionConstants.java
@@ -318,7 +318,7 @@ public class SensisionConstants {
   /**
    * Number of datapoints deleted by 'standalone' delete per owner and application
    */
-  public static final String SENSISION_CLASS_CONTINUUM_STANDALONE_DELETE_DATAPOINTS_PEROWNER = "warp.standalone.delete.datapoints.perowner";
+  public static final String SENSISION_CLASS_CONTINUUM_STANDALONE_DELETE_DATAPOINTS_PEROWNERAPP = "warp.standalone.delete.datapoints.perownerapp";
 
   /**
    * Number of GTS deleted by 'standalone' delete
@@ -508,7 +508,7 @@ public class SensisionConstants {
   /**
    * Number of datapoints deleted by 'Store' per owner and application
    */
-  public static final String SENSISION_CLASS_CONTINUUM_STORE_HBASE_DELETE_DATAPOINTS_PEROWNER = "warp.store.hbase.delete.datapoints.perowner";
+  public static final String SENSISION_CLASS_CONTINUUM_STORE_HBASE_DELETE_DATAPOINTS_PEROWNERAPP = "warp.store.hbase.delete.datapoints.perownerapp";
 
   /**
    * Number of results retrieved from scanners by HBaseStoreClient

--- a/warp10/src/main/java/io/warp10/continuum/store/Store.java
+++ b/warp10/src/main/java/io/warp10/continuum/store/Store.java
@@ -1018,7 +1018,7 @@ public class Store extends Thread {
         Map<String, String> labels = new HashMap<>();
         labels.put(Constants.OWNER_LABEL, meta.getLabels().get(Constants.OWNER_LABEL));
         labels.put(Constants.APPLICATION_LABEL, meta.getLabels().get(Constants.APPLICATION_LABEL));
-        Sensision.update(SensisionConstants.SENSISION_CLASS_CONTINUUM_STORE_HBASE_DELETE_DATAPOINTS_PEROWNER, labels, noOfDeletedVersions);
+        Sensision.update(SensisionConstants.SENSISION_CLASS_CONTINUUM_STORE_HBASE_DELETE_DATAPOINTS_PEROWNERAPP, labels, noOfDeletedVersions);
       }
     }
     

--- a/warp10/src/main/java/io/warp10/continuum/store/Store.java
+++ b/warp10/src/main/java/io/warp10/continuum/store/Store.java
@@ -16,7 +16,6 @@
 
 package io.warp10.continuum.store;
 
-import com.sun.xml.bind.v2.runtime.reflect.opt.Const;
 import io.warp10.continuum.KafkaOffsetCounters;
 import io.warp10.continuum.gts.GTSDecoder;
 import io.warp10.continuum.gts.GTSEncoder;
@@ -1017,20 +1016,9 @@ public class Store extends Thread {
       Metadata meta = msg.getMetadata();
       if (null != meta) {
         Map<String, String> labels = new HashMap<>();
-
-        String owner = meta.getLabels().get(Constants.OWNER_LABEL);
-        if (null != owner) {
-          labels.put(Constants.OWNER_LABEL, owner);
-        }
-
-        String app = meta.getLabels().get(Constants.APPLICATION_LABEL);
-        if (null != app) {
-          labels.put(Constants.APPLICATION_LABEL, app);
-        }
-
-        if (!labels.isEmpty()) {
-          Sensision.update(SensisionConstants.SENSISION_CLASS_CONTINUUM_STORE_HBASE_DELETE_DATAPOINTS_PEROWNER, labels, noOfDeletedVersions);
-        }
+        labels.put(Constants.OWNER_LABEL, meta.getLabels().get(Constants.OWNER_LABEL));
+        labels.put(Constants.APPLICATION_LABEL, meta.getLabels().get(Constants.APPLICATION_LABEL));
+        Sensision.update(SensisionConstants.SENSISION_CLASS_CONTINUUM_STORE_HBASE_DELETE_DATAPOINTS_PEROWNER, labels, noOfDeletedVersions);
       }
     }
     

--- a/warp10/src/main/java/io/warp10/standalone/StandaloneDeleteHandler.java
+++ b/warp10/src/main/java/io/warp10/standalone/StandaloneDeleteHandler.java
@@ -273,7 +273,9 @@ public class StandaloneDeleteHandler extends AbstractHandler {
         // Remove data
         //
         
-        count += this.storeClient.delete(writeToken, metadata, start, end);
+        long localCount = this.storeClient.delete(writeToken, metadata, start, end);
+        count += localCount;
+
         sb.setLength(0);
         GTSHelper.metadataToString(sb, metadata.getName(), metadata.getLabels());
         
@@ -288,6 +290,23 @@ public class StandaloneDeleteHandler extends AbstractHandler {
         metas.append(sb);
         metas.append("\n");
         gts++;
+
+        // Log detailed metrics for this GTS owner and app
+        Map<String, String> labels = new HashMap<>();
+
+        String metaOwner = metadata.getLabels().get(Constants.OWNER_LABEL);
+        if (null != metaOwner) {
+          labels.put(Constants.OWNER_LABEL, metaOwner);
+        }
+
+        String metaAapp = metadata.getLabels().get(Constants.APPLICATION_LABEL);
+        if (null != metaAapp) {
+          labels.put(Constants.APPLICATION_LABEL, metaAapp);
+        }
+
+        if (!labels.isEmpty()) {
+          Sensision.update(SensisionConstants.SENSISION_CLASS_CONTINUUM_STORE_HBASE_DELETE_DATAPOINTS_PEROWNER, labels, localCount);
+        }
       }
     } catch (Exception e) {
       t = e;

--- a/warp10/src/main/java/io/warp10/standalone/StandaloneDeleteHandler.java
+++ b/warp10/src/main/java/io/warp10/standalone/StandaloneDeleteHandler.java
@@ -293,20 +293,9 @@ public class StandaloneDeleteHandler extends AbstractHandler {
 
         // Log detailed metrics for this GTS owner and app
         Map<String, String> labels = new HashMap<>();
-
-        String metaOwner = metadata.getLabels().get(Constants.OWNER_LABEL);
-        if (null != metaOwner) {
-          labels.put(Constants.OWNER_LABEL, metaOwner);
-        }
-
-        String metaAapp = metadata.getLabels().get(Constants.APPLICATION_LABEL);
-        if (null != metaAapp) {
-          labels.put(Constants.APPLICATION_LABEL, metaAapp);
-        }
-
-        if (!labels.isEmpty()) {
-          Sensision.update(SensisionConstants.SENSISION_CLASS_CONTINUUM_STORE_HBASE_DELETE_DATAPOINTS_PEROWNER, labels, localCount);
-        }
+        labels.put(Constants.OWNER_LABEL, metadata.getLabels().get(Constants.OWNER_LABEL));
+        labels.put(Constants.APPLICATION_LABEL, metadata.getLabels().get(Constants.APPLICATION_LABEL));
+        Sensision.update(SensisionConstants.SENSISION_CLASS_CONTINUUM_STANDALONE_DELETE_DATAPOINTS_PEROWNER, labels, localCount);
       }
     } catch (Exception e) {
       t = e;

--- a/warp10/src/main/java/io/warp10/standalone/StandaloneDeleteHandler.java
+++ b/warp10/src/main/java/io/warp10/standalone/StandaloneDeleteHandler.java
@@ -295,7 +295,7 @@ public class StandaloneDeleteHandler extends AbstractHandler {
         Map<String, String> labels = new HashMap<>();
         labels.put(Constants.OWNER_LABEL, metadata.getLabels().get(Constants.OWNER_LABEL));
         labels.put(Constants.APPLICATION_LABEL, metadata.getLabels().get(Constants.APPLICATION_LABEL));
-        Sensision.update(SensisionConstants.SENSISION_CLASS_CONTINUUM_STANDALONE_DELETE_DATAPOINTS_PEROWNER, labels, localCount);
+        Sensision.update(SensisionConstants.SENSISION_CLASS_CONTINUUM_STANDALONE_DELETE_DATAPOINTS_PEROWNERAPP, labels, localCount);
       }
     } catch (Exception e) {
       t = e;

--- a/warp10/src/main/thrift/io_warp10_continuum_store_thrift_data.thrift
+++ b/warp10/src/main/thrift/io_warp10_continuum_store_thrift_data.thrift
@@ -95,6 +95,11 @@ struct KafkaDataMessage {
    * Minimum age of cells to delete (in ms)
    */
   8: optional i64 deletionMinAge,
+
+  /**
+   * Optional metadata
+   */
+  9: optional Metadata metadata,
 }
 
 /**


### PR DESCRIPTION
For accounting purposes, I need to have a fine grained visibility on the number of points deleted by a particular user. This change reports in Sensision the count of deleted points associated to the owner (and app if present).
This is optional (and disabled by default) for the HBase version, and always active for the standalone version.