### PR TITLE
Change repo from maven to generic

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -799,7 +799,7 @@ project(':hbaseFilters') {
     publishing {
         publications {
             hbaseFilters(MavenPublication) {
-                from components.java
+                artifact file("${buildDir}/libs/hbaseFilters-" + getVersionName(warp10Version['warp10']) + ".jar")
                 groupId 'io.warp10'
                 artifactId archivesBaseName
                 version version
@@ -816,7 +816,7 @@ project(':hbaseFilters') {
         publications = [ 'hbaseFilters' ]
 
         pkg {
-            repo = 'maven'
+            repo = 'generic'
             name = 'hbaseFilters'
             licenses = ['Apache-2.0']
             vcsUrl = 'https://github.com/cityzendata/warp10-platform.git'


### PR DESCRIPTION
HbaseFilters is not a maven dependence, but an install component for HBase used by Warp10 platform. 