### PR TITLE
Add Changelog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,10 +17,18 @@
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url "https://plugins.gradle.org/m2"
+        }
+    }
+    dependencies {
+        classpath "gradle.plugin.com.selesse:gradle-git-changelog:0.2.0"
     }
 }
+
 plugins {
     id "com.jfrog.bintray" version "1.4"
+    id "com.selesse.git.changelog" version "0.2.0"
 }
 
 allprojects {
@@ -124,6 +132,7 @@ subprojects {
         maven {
             url 'https://dl.bintray.com/cityzendata/maven'
         }
+
         //maven {
         //  url "https://repository.apache.org/content/repositories/orgapachehbase-1065"
         //}
@@ -566,10 +575,81 @@ project(':warp10') {
         }
     }
 
+    changelog {
+        // The title appears at the top of the changelog.
+        // Default value: the name of the project.
+        title = "${project.name} - Changelog"
+
+        // The output directory where the report is generated.
+        // Default value: main resource directory, or the "build" directory
+        outputDirectory = file("$projectDir")
+
+        // The name of the report to generate.
+        // Default value: CHANGELOG.md
+        fileName = "changelog.txt"
+
+        // The range of commits the changelog should be composed of.
+        // Default value: 'beginning' (i.e. full changelog)
+        // Possible values: 'beginning', 'last_tag', 'xxx'
+        //
+        // 'last_tag' will use all the commits since the last tag,
+        // 'beginning' will use all commits since the initial commit (default)
+        // 'xxx' will use all the tags since the 'xxx' Git reference (i.e. `since = 1.2.0` will display the changelog
+        //       since the 1.2.0 tag, excluding 1.2.0)
+        since = 'beginning'
+
+        // The output formats that should be generated.
+        // Default value: ['markdown']
+        // Possible values: 'html', 'markdown'.
+        formats = ['html', 'markdown']
+
+
+        // The Git "pretty" changelog commit format.
+        // Default value: %ad%x09%s (%an), which produces:
+        // Thu May 7 20:10:33 2015 -0400    Initial commit (Alex Selesse)
+        commitFormat = '%ad%x09%s'
+
+        // Specifies a commit format for Markdown.
+        // Default value: '* %s (%an)', which produces:
+        // * Initial commit (Alex Selesse)
+        markdown {
+            commitFormat = '* %s'
+        }
+
+        // Specifies a commit format for the HTML template.
+        // Default value: see commitFormat
+        html {
+            commitFormat = '%s'
+
+            // The Groovy HTML template used to generate the HTML changelog.
+            // See http://docs.groovy-lang.org/latest/html/documentation/template-engines.html
+        //    template = file("$projectDir/htmlTemplate").text
+        }
+
+        // A closure that returns 'true' if the line should be included in the changelog.
+        // Default value: accept everything, { true }
+        includeLines = {
+            !it.contains("Merge")
+        }
+
+        // A closure that transforms a changelog String.
+        // Default value: the identity closure, { it }
+        //
+        // For example, to remove '[ci skip]' from the changelog messages:
+        //processLines = {
+        //    String input = it as String
+        //    if (input.contains('[ci skip] ')) {
+        //        input = input.minus('[ci skip] ')
+        //    }
+        //    input
+        //}
+    }
+
     //
     // Tasks dependencies
     //
     compileJava.dependsOn generateThrift
+    pack.dependsOn generateChangelog
     uploadArchives.dependsOn pack
     bintrayUpload.dependsOn createTarArchive
 }

--- a/warp10/src/main/sh/package.sh
+++ b/warp10/src/main/sh/package.sh
@@ -37,6 +37,7 @@ chmod 755 ${WARP10_HOME}/bin/warp10-standalone.bootstrap
 # Copy log4j README, config, bootstrap...
 cp ../../etc/bootstrap/*.mc2 ${WARP10_HOME}/etc/bootstrap
 cp ../../etc/install/README.md ${WARP10_HOME}
+cp ${WARP_ROOT_PATH}/changelog.* ${WARP10_HOME}
 
 sed -e "s/@VERSION@/${VERSION}/g" ../../etc/log4j.properties >> ${WARP10_HOME}/etc/log4j.properties
 


### PR DESCRIPTION
warp10 - Changelog
==================

Unreleased
----------
* Changelist to make Warp10 compatible with JDK7 again...
* Fix extension .tar.gz
* Refactored to index classes per owner instead of per producer as producer is only rarely specified in ReadTokens.
* Added forcing of GC right after loading the initial GTS. Changed type of labelValues to use an array instead of a List
* Addec class statistics in LOG message
* Added INFO log message with detailed stats on directory search.
* Added support for specifying partition.assignment.strategy. Corrected minor tweaks for client.id configuration
* Added calls to maxLimits
* Modified a catch clause so we trap IllegalArgumentException which is thrown instead of IOException when closing a table.
* Added publishing or per server metrics for HBase client
* Changed the way we handle '|'
* Corrected escaping sequence
* Fixed incorrect index.
* Fixed incorrect labelValues size
* Optimized streaming requests Metadata selection. Refactored Metadata selection similarly for find and stats
* Sped up Metadata selection.
* Modified the way depth control is performed. Added interface Snapshotable
* Added missing reset of StringBuilder
* Added check of requested number of levels in dump
* Modified the way HBase connection reset are performed. This should solve a case when the pool is exhausted.
* Removed printStackTrace call
* Added WRAPPER output format for feeding into storm topologies.
* Added signature to limit number of compression passes.
* Initial commit of REXEC
* Added method maxLimits
* Fix error with snapshot of Leveldb when data directory is a symlink
* Initial commit
* Minor fixes
* Changed createIfMissing from true to false. Added WarpInit and WarpRepair.
* Replaced quote_plus by quote
* Added support for NamedWarpScriptFunction when representing a macro
* Replaced uses of URLEncoded with WarpURLEncoder
* Initial commit of Python skeleton callable.
* Added comment
* Addec nullity check for properties
* Modified input/output order
* Added support for NULLs
* Added NULL
* Corrected incorrect handling of byte[].
* sensision 1.0.5
* warpscript: add Configuration.class

1.0.7 (2016-06-09 13:01:55 +0200)
---------------------------------
* WarpScriptExecutor: add Progressable parameter in constructor
* Fix error in the type of config parameter: long instead of int
* Added 'check' URI which always return 200 so services can be put behind a load balancer which only know how to do HTTP checks.
* Added overlapping parameter. This is a breaking change, but CHUNK is not yet used.
* Added setProperties which takes a Reader as parameter
* Changed buildSelector to use a TreeMap
* Added setting of client.id if configured.
* encoder can be null...
* set count attribute for each chunk (GTSWrapper)
* warp10 standalone init: default Xmx=1g
* moves standalone.home
* Version name variabilisation move templates into template directory updates packaging
* Added pyrolite. Bumped Kafka to 2.11/0.8.2.2
* Initial commit of CALL/PICKLETO/TOPICKLE/WRAPRAW/RTFM
* Added support for byte array
* Added try/catch Throwable around ref to WarpDist so we can work in lib mode
* Added reading of MAXWAIT config. Prepared for per producer/app maxwait values.
* Added doc URL
* Added CALL and THROTTLING related config keys.
* Wrapped call to WarpDist.getKeyStore into a try/catch so it does not fail in warpscript lib
* Refactored toString of many functions. Refactored SNAPSHOT.
* Cleaned imports
* Refactored to use StackUtils.toString
* Added method toString(Object)
* Initial commit of RANDPDF
* Initial commit of PACK/UNPACK/GEOPACK/GEOUNPACK

1.0.6 (2016-05-09 12:46:49 +0200)
---------------------------------
* Added support for disabling proxy for Directory Streaming Requests.
* Initial commit of CPROB
* Intial commit of Morton code functions ->Z and Z->
* Intial commit of Morton code functions ->Z and Z->
* Add support for 'hbase.zookeeper.property.clientport' hbase option.
* Moved configuration parameters into Configuration
* Added webcall configuration parameters. Added clientid params.
* Added client.id for Kafka producer/consumer
* Intial commit of function PROB
* Corrected bug for 'compact' when GTS is empty. Added methods 'prob' and 'cprob'
* Fixes #28 - Added dump of LKP index upon shutdown and load upon startup
* Fixes #53 - Added support for client.id Kafka property
* Added specific handling of exact class matches
* Corrected toString of STRICTMAPPER
* Added support for vectors and matrices in ADD/SUB/DIV/MUL
* Added linear algebra functions. Added STRICTREDUCER
* Added urlencoding and null string parameters to Join
* Revert it (never commit revision)
* install thrift into /usr/loca/bin
* test thrift binary from url
* change arch to amd64
* change arch to amd64
* install thrift by package
* adds thrift version on the output (bad version with travis ?)
* try build  this 3 steps
* try build  this 3 steps
* don't skip install
* revert last commit (error)
* adds trusty dist
* test trigger
* install thrift compiler
* 	modifié:         .travis.yml
* install thrift compiler
* chain commands
* Adds travis configuration
* Adds travis configuration
* Adds travis configuration
* Initial commit of SNAPSHOT
* Added metrics for snapshot counting. Reduced waiting time.
* Added premature return when removing a stack attribute
* Change repo from maven to generic
* formatting
* Adds HbaseFilters packaging and publication task
* Corrected warp.timeunits value
* Removed ref to component 'delete' which no longer exists
* Added support for '> alone on a line instead of simply at the beginning of the line
* Adds missing true/false constants
* Added FIXME comment.
* Corrected Sensision labels for owner/app
* Added paramter 'showattr' for /fetch endpoint to output the attributes.
* Added method rewrap
* Move package name
* Updates comments
* Interrupt extraction if functions list is not readable
* replace strings by constants
* Split map framework and add misc functions
* Corrected comment. Changed while check against compratio to a strict comparison
* Modified behaviour when compratio is < 1.0D
* Initial commit of BITCOUNT
* Removed function DEVICES. Added BYTESTOBITS and BITSTOBYTES
* Added methods which can set the compression ratio threshold
* Adds function extraction
* Update README.md
* Corrected check
* Modified B64-> B64URL-> HEX-> to output a byte array. Added BIN-> OPB64->. Modified the reverse functions to support byte arrays.

1.0.5 (2016-04-25 11:24:00 +0200)
---------------------------------
* Initial commit of TOBOLOEAN. Refactored MAP/REDUCE so they can produce multiple GTS as output.
* Changed the way the property is retrieved for ipc pool size
* Corrected parsing of hexadecimal and binary numbers so it supports single digit representations.
* Added config parameter egress.hbase.client.ipc.pool.size
* Added config parameter store.hbase.client.ipc.pool.size
* Added detailed IOException message in WarpScript exception thrown
* Added nullification of conn.
* Added nullification of conn.
* Corrected output.
* Added support for token in header
* Added support for dryrun
* Added parameters for DELETE
* Initial commit of DELETE
* Initial commit of BITGET
* Changed logging level from error to debug. Changed catch clause to a more general Throwable instead of IOException.
* Refactored the HBase connection management and retrial on error.
* Added removal of GTS_DISTINCT metric when clearing the estimator.
* Added metric for number of committed puts in HBase.
* Replaced Thread.sleep by calls to LockSupport.parkNanos
* Modified thread name. Changed while condition.
* sfetch metrics: clear labels
* rename sensision metrics .wrapper into .wrappers
* Add Sensision metrics for fetch/sfetch requests

1.0.4 (2016-04-13 19:49:10 +0200)
---------------------------------
* InputFormat: Log only the fetch endpoint without token
* remove useless import statements
* update configuration template related to the standalone mode
* LoadFunc: add progress() to provide a better status of the job that is currently running
* Warp10InputFormat: add read timeout parameter
* Optimized compression.
* Added support for using only the fallback fetchers
* Corrected the multi-pass compression so we do not use compression when it is not needed
* Corrected count.
* Added missing 'break'
* Added support for controlling number of splits

1.0.3 (2016-04-11 11:22:12 +0200)
---------------------------------
* Added support for TSV format.
* Warp10InputFormat: replace System.out by SLF4J Logger
* Warp10 publishing: fix error
* Warp10InputFormat: add logs

1.0.2 (2016-04-08 11:53:54 +0200)
---------------------------------
* Added default constructor
* Added geodir.dump.prefix
* Added constructors
* Initial commit of gts2csv.py
* Changed metric name
* Removed unnecessary tests, changed default values, fixed standalone metric name
* Added detailed deletion metrics
* Added computation of mean of location and elevation
* Initial commit of CircularMean
* warpscript: fix error during bintray publishing
* Warp10InputFormat: fix errors - move to mapreduce V2 api
* warpscript publishing: add libthrift
* delete unused import (not found)
* Initial commit of region cache clearing upon HBase IO Exception in Store
* Corrected depth increment to avoid overflow.
* Added support for validator in APPLY
* Changed the way extra languages are triggered. We now use WarpConfig.
* Added TODO
* Replaced uses of synchronized by ReentrantLock. Added setting of maximum URI size for streaming requests.
* Warp10InputFormat: moved to mapreduce V2 API
* warpscript: get crypto/token classes from their dedicated(restore)…
* Added support for converting GTS to string.
* warpscript: include hadoop package
* use /opt/thrift if it exists
* restore default values for warpScriptPublishUser/URL
* Warpscript publishing: move the iteration of dependencies (build failed)
* Warpscript publication: specify the list of dependencies names but do not specify version
* Set default values to warpScriptPublishUser/URL parameters
* use /opt/thrift if it exists
* Warpscript publishing: add InputFormat and its dependencies
* warpscript publishing: get crypto/token classes from their dedicated projects
* warpscript publishing: delete dependencies block
* warpscript publishing: add specific dependencies
* warpscript publishing: add deps
* warpscript publishing: function to generate Warpscript pom
* build.gradle: warpscript publishing
* Fixes #30 - Added support for multiple selectors.
* Initial commit of EXPORT
* Added setRaw(true) for the scanner used for the BulkDeleteEndpoint so we correctly delete versions for data still in Memstore
* Corrected DeleteType for the case when minage is set.
* Modified DeleteType to ROW instead of VERSION as the latter does not work as expected, see HBASE-15487
* Added synchronization
* Refactored sync again around metadataCache
* Corrected import for Arrays
* Modified the synchronization of metadataCache so we don't alter the ingestion performances too much
* Added synchronization around access to metadataCache so the dump works correctly.
* Replaced Thread.sleep by parkNanos
* Added comments
* Added regeneration of HBase connection.
* Added check for barrier nullity prior to resetting it.
* Removed twitter4j
* Removed TWITTERDM, this should be a UDF, not in WarpScript.
* Added egress.hbase.data.blockcache.gts.threshold
* Modified symbol table handling
* Added method fromGTSWrappertoGTSDecoder
* Replaced synchronized blocks with ReentrantLock
* Added getSynchronizer and explicit interrupt of synchronizer thread on shutdown.
* Fixes #27 - Added premature return when one of the GTS is empty
* Added generation number in thread name. Changed barrier synchronization to a timed one.
* Added barrier reset
* Added forcing of localabort when shutting down the executor
* Added logging
* Removed barrier reset
* Added barrier reset. Corrected reference to barrier so we do not await on the newly allocated one. Added error logging
* Corrected typo.
* rename warpscript group
* Fixes #8 - Added configuration parameter to enable the block cache for scanners.
* update building to build Warp10 with thrift-0.9.1
* update building to build Warpto with thrift-0.9.1
* Fixes #21 - Added cast to int for MAXDEPTH/MAXSYMBOLS limits
* Add some lines on building.md about the setup of thrift on MAC OS for Warp10
* Initial commit of Hadoop InputFormat
* Added method getId
* Added check for token nullity prior to updating Sensision metrics
* Added output of GTSWrapper ID
* Corrected header key for timespan
* Added region encoded name in output so splits can be grouped either by RegionServer and/or by Region
* Added iterator to the list
* Added handling of /sftech request
* Added timespan header. Added header extraction instead of parameter retrieval in /sfetch
* Corrected index which was off by one
* Removed token from split to shorten its length. Added expiry so we reflect the token's expiry in the split.
* Added missing parameters to DirectoryClient.iterator call
* Added forcing of 'signed' status when retrieving splits
* Initial support of GTSSplit
* Corrected computation so result is in meters. Modified Earth radius with the WGS84 ellipsoid radius in meters
* Added key AES_FETCHER
* fix simplified
* fix bug on ZIP function when handling a list with only singletons
* Removed class loading restrictions, they were a residue of the time when Warp was distributed as a protected jar
* Added check for interrupted status
* Fixes #14 - Replaced joda-time with JSR-310. Dropped support for non zoned timestamps which should not have been supported anyway.
* Cleaned imports
* Added logging. Replaced calls to Thread.sleep with calls to LockSupport.park. Switched shutdown of Kafka connector and executor
* Added interruption of the synchronizer thread when the consumer is aborting.
* Added method fromGTSEncoderToGTSWrapper
* Added check if session is open before dispatching data to it. We get a chance to close a session for which we have missed the closing event
* Modified output format of URLFETCH so it is valid JSON (status msg was in the headers' map with a null key)
* Fix GTSHelper.quicksortByLocation
* Added flag to disable StandalonePlasmaHandler thread start
* Added copy of raw array retrieved from NodeCache
* Corrected the clearing of subscriptions.
* Made UUID unique for a subscription, this will simplify identification of znodes
* Made sendDataMessage synchronized
* Added Sensision metrics for data consumption
* Added missing call to onChange on the subscriptionListener when clearing subscriptions
* Added support for 'raw' UDFs which will be called with the stack as parameter
* Refactored the way the Warp10 configuration is loaded. Initial commit of WarpConfig.
* Added support for 'null' File in readConfig so we can simply consider system properties
* Added support for loading macros from directories in the classpath.
* Added support for String in SIZE
* Added intermediary copy of metadataCache so we can iterate without risking CMEs
* Fix hardcoded thrift path
* Fixes #10 - Added tracking of expired estimators
* Added required authentication for URLFETCH
* Initial commit of OPB64TOHEX and URLFETCH
* Bumped Sensision rev to 1.0.2
* Corrected thread name. Corrected size of cyclic barrier
* Modified thread name for Synchronizer and Spawner
* Added flag to check for (re)init of the pool. Without this the Synchronizer could die. Also removed the 'return' from the Synchronizer loop
* Fixes #9 - Added configuration for setting Kafka request timeout for topic data
* Added closing of Table instance upon exit.
* targz: add README.md
* Added bucketizers/mappers dealing with nulls in a specific way. Those were removed but they are needed since applying MAP/BUCKETIZE on a bucketized GTS will materialize the nulls.
* Fixes #6 - Changed default BootstrapManager period to 0L.
* Fixes #5 - Added missing close of BufferedReader
* update Building setup
* Added forcing of charset when encoding bSAX
* Added comments
* Fixes #4 - Corrected maxtime used in loop
* Fixes #3 - Added output of attributes for /delete and /find in both standalone and distributed versions.
* Fixes #2 - Registered handler for /find

1.0.1 (2016-01-28 21:30:23 +0100)
---------------------------------
* Fixes #1 - Added setting of 'previousLastXXXValue' when encountering identical values. Initial commit of migrated GTSEncoder/GTSDecoder tests.

1.0.0 (2016-01-28 18:31:38 +0100)
---------------------------------
* Added missing Revision file
* Initial GitHub commit.
