### PR TITLE
Remove zookeeper.connect propertie for producerconfig

### DIFF
--- a/warp10/src/main/java/io/warp10/continuum/KafkaWebCallService.java
+++ b/warp10/src/main/java/io/warp10/continuum/KafkaWebCallService.java
@@ -121,7 +121,6 @@ public class KafkaWebCallService {
 
     Properties properties = new Properties();
     // @see http://kafka.apache.org/documentation.html#producerconfigs
-    properties.setProperty("zookeeper.connect", props.getProperty(Configuration.WEBCALL_KAFKA_ZKCONNECT));
     properties.setProperty("metadata.broker.list", props.getProperty(Configuration.WEBCALL_KAFKA_BROKERLIST));
     
     if (null != props.getProperty(Configuration.WEBCALL_KAFKA_PRODUCER_CLIENTID)) {

--- a/warp10/src/main/java/io/warp10/continuum/geo/GeoDirectory.java
+++ b/warp10/src/main/java/io/warp10/continuum/geo/GeoDirectory.java
@@ -408,7 +408,6 @@ public class GeoDirectory extends AbstractHandler implements Runnable, GeoDirect
     
     Properties subsProps = new Properties();
     // @see http://kafka.apache.org/documentation.html#producerconfigs
-    subsProps.setProperty("zookeeper.connect", properties.getProperty(Configuration.GEODIR_KAFKA_SUBS_ZKCONNECT));
     subsProps.setProperty("metadata.broker.list", properties.getProperty(Configuration.GEODIR_KAFKA_SUBS_BROKERLIST));
     if (null != properties.getProperty(Configuration.GEODIR_KAFKA_SUBS_PRODUCER_CLIENTID)) {
       subsProps.setProperty("client.id", properties.getProperty(Configuration.GEODIR_KAFKA_SUBS_PRODUCER_CLIENTID));
@@ -428,7 +427,6 @@ public class GeoDirectory extends AbstractHandler implements Runnable, GeoDirect
     
     Properties plasmaProps = new Properties();
     // @see http://kafka.apache.org/documentation.html#producerconfigs
-    plasmaProps.setProperty("zookeeper.connect", properties.getProperty(Configuration.GEODIR_KAFKA_DATA_ZKCONNECT));
     plasmaProps.setProperty("metadata.broker.list", properties.getProperty(Configuration.GEODIR_KAFKA_DATA_BROKERLIST));
     if (null != properties.getProperty(Configuration.GEODIR_KAFKA_DATA_PRODUCER_CLIENTID)) {
       plasmaProps.setProperty("client.id", properties.getProperty(Configuration.GEODIR_KAFKA_DATA_PRODUCER_CLIENTID));

--- a/warp10/src/main/java/io/warp10/continuum/ingress/Ingress.java
+++ b/warp10/src/main/java/io/warp10/continuum/ingress/Ingress.java
@@ -319,7 +319,6 @@ public class Ingress extends AbstractHandler implements Runnable {
     
     Properties metaProps = new Properties();
     // @see http://kafka.apache.org/documentation.html#producerconfigs
-    metaProps.setProperty("zookeeper.connect", props.getProperty(Configuration.INGRESS_KAFKA_META_ZKCONNECT));
     metaProps.setProperty("metadata.broker.list", props.getProperty(Configuration.INGRESS_KAFKA_META_BROKERLIST));
     if (null != props.getProperty(Configuration.INGRESS_KAFKA_META_PRODUCER_CLIENTID)) {
       metaProps.setProperty("client.id", props.getProperty(Configuration.INGRESS_KAFKA_META_PRODUCER_CLIENTID));
@@ -343,7 +342,6 @@ public class Ingress extends AbstractHandler implements Runnable {
     
     Properties dataProps = new Properties();
     // @see http://kafka.apache.org/documentation.html#producerconfigs
-    dataProps.setProperty("zookeeper.connect", props.getProperty(Configuration.INGRESS_KAFKA_DATA_ZKCONNECT));
     dataProps.setProperty("metadata.broker.list", props.getProperty(Configuration.INGRESS_KAFKA_DATA_BROKERLIST));
     if (null != props.getProperty(Configuration.INGRESS_KAFKA_DATA_PRODUCER_CLIENTID)) {
       dataProps.setProperty("client.id", props.getProperty(Configuration.INGRESS_KAFKA_DATA_PRODUCER_CLIENTID));
@@ -385,7 +383,6 @@ public class Ingress extends AbstractHandler implements Runnable {
     /*
     Properties deleteProps = new Properties();
     // @see http://kafka.apache.org/documentation.html#producerconfigs
-    deleteProps.setProperty("zookeeper.connect", props.getProperty(INGRESS_KAFKA_D_ZKCONNECT));
     deleteProps.setProperty("metadata.broker.list", props.getProperty(INGRESS_KAFKA_DELETE_BROKERLIST));
     deleteProps.setProperty("request.required.acks", "-1");
     deleteProps.setProperty("producer.type","sync");

--- a/warp10/src/main/java/io/warp10/continuum/plasma/PlasmaBackEnd.java
+++ b/warp10/src/main/java/io/warp10/continuum/plasma/PlasmaBackEnd.java
@@ -157,7 +157,6 @@ public class PlasmaBackEnd extends Thread implements NodeCacheListener {
     
     Properties dataProps = new Properties();
     // @see http://kafka.apache.org/documentation.html#producerconfigs
-    dataProps.setProperty("zookeeper.connect", props.getProperty(io.warp10.continuum.Configuration.PLASMA_BACKEND_KAFKA_OUT_ZKCONNECT));
     dataProps.setProperty("metadata.broker.list", props.getProperty(io.warp10.continuum.Configuration.PLASMA_BACKEND_KAFKA_OUT_BROKERLIST));
     if (null != props.getProperty(io.warp10.continuum.Configuration.PLASMA_BACKEND_KAFKA_OUT_PRODUCER_CLIENTID)) {
       dataProps.setProperty("client.id", props.getProperty(io.warp10.continuum.Configuration.PLASMA_BACKEND_KAFKA_OUT_PRODUCER_CLIENTID));

--- a/warp10/src/main/java/io/warp10/script/ScriptRunner.java
+++ b/warp10/src/main/java/io/warp10/script/ScriptRunner.java
@@ -262,7 +262,6 @@ public class ScriptRunner extends Thread {
       
       Properties props = new Properties();
       // @see http://kafka.apache.org/documentation.html#producerconfigs
-      props.setProperty("zookeeper.connect", props.getProperty(Configuration.RUNNER_KAFKA_ZKCONNECT));
       props.setProperty("metadata.broker.list", props.getProperty(Configuration.RUNNER_KAFKA_BROKERLIST));
       if (null != props.getProperty(Configuration.RUNNER_KAFKA_PRODUCER_CLIENTID)) {
         props.setProperty("client.id", props.getProperty(Configuration.RUNNER_KAFKA_PRODUCER_CLIENTID));


### PR DESCRIPTION
As mentioned in the documentation, http://kafka.apache.org/documentation.html#producerconfigs, zookeeper.connect doest not exist for KafkaProducer. Removing it also correct unwanted Warning log "WARN  utils.VerifiableProperties - Property zookeeper.connect is not valid" that can lead to unnecessary debugging.

