### PR TITLE
Standalone datalog forwarder

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -482,7 +482,7 @@ project(':warp10') {
         //
         // Java Merge Sort
         //
-        compile group: 'com.fasterxml', name: 'java-merge-sort', version: '0.5.3'
+        compile group: 'com.fasterxml.util', name: 'java-merge-sort', version: '1.0.0'
 
         // @see http://www.mail-archive.com/dev@kafka.apache.org/msg03829.html
         //compile("org.apache.kafka:kafka_2.9.2:0.8.1.1") {

--- a/etc/conf-standalone.template
+++ b/etc/conf-standalone.template
@@ -278,13 +278,76 @@ standalone.snapshot.signal = ${standalone.home}/data/snapshot.signal
 // a file in this directory with the timestamp, the token used and the action type. These files can then
 // be used to update another instance of Warp 10
 //
-#standalone.datalog.dir = ${standalone.home}/datalog
+#datalog.dir = ${standalone.home}/datalog
 
 //
-// Datalog token key. If this AES key is set, the token will be encrypted prior to be used in the file name
-// mentioned above.
+// Unique id for this datalog instance.
 //
-#standalone.datalog.aes = hex:hhhhhhhh....
+#datalog.id = datalog-0
+
+//
+// Datalog pre-shared key to protect the DatalogRequest instances. If this AES key is not set, the requests will not be
+// encrypted and could be altered.
+//
+#datalog.psk = hex:hhhhhhhh....
+
+//
+// Directory where datalog files to forward reside. If this property and 'datalog.forwarder.dstdir' are set, then
+// the DatalogForwarder daemon will run.
+//
+#datalog.forwarder.srcdir =
+
+//
+// Directory where forwarded datalog files will be moved. MUST be on the same device as datalog.forwarder.srcdir
+//
+#datalog.forwarder.dstdir =
+
+//
+// How often (in ms) to scan 'datalog.forwarder.srcdir' for datalog files to forward
+//
+#datalog.forwarder.period = 1000
+
+//
+// Comma separated list of datalog ids which should not be forwarded. This is used to avoid loops.
+//
+#datalog.forwarder.ignored =
+
+//
+// Set this property to 'true' to compress the forwarded requests
+//
+#datalog.forwarder.compress = true
+
+//
+// Set this property to 'true' to behave like a normal Warp 10 client. If not set to 'true' then
+// the original datalog requests will be forwarded. Set to 'true' when forwarding to a distributed Warp 10.
+//
+#datalog.forwarder.actasclient = true
+
+//
+// Number of threads which will process the datalog requests. Requests for a identical (producer,app,owner) tuple
+// will always be processed by the same thread to guarantee the sequence of actions.
+//
+#datalog.forwarder.nthreads = 4
+
+//
+// Endpoint to use when forwarding datalog UPDATE requests.
+//
+#datalog.forwarder.endpoint.update = http://host:port/api/v0/update
+
+//
+// Endpoint to use when forwarding datalog META requests.
+//
+#datalog.forwarder.endpoint.meta = http://host:port/api/v0/meta
+
+//
+// Endpoint to use when forwarding datalog DELETE requests.
+//
+#datalog.forwarder.endpoint.delete = http://host:port/api/v0/delete
+
+//
+// Configuration parameter to modify the datalog header. DO NOT MODIFY
+//
+#http.header.datalog =
 
 //
 // Max message size for the stream update websockets

--- a/warp10/src/main/java/io/warp10/SortedPathIterator.java
+++ b/warp10/src/main/java/io/warp10/SortedPathIterator.java
@@ -1,0 +1,49 @@
+package io.warp10;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Iterator;
+
+import com.fasterxml.sort.DataReader;
+import com.fasterxml.sort.SortConfig;
+import com.fasterxml.sort.Sorter;
+import com.fasterxml.sort.std.TextFileSorter;
+import com.google.common.base.Charsets;
+
+public class SortedPathIterator implements Iterator<Path> {
+  
+  private final Iterator<byte[]> sortedIter;
+  
+  public SortedPathIterator(final Iterator<Path> iter) throws IOException {
+    SortConfig config = new SortConfig().withMaxMemoryUsage(1000000);
+    Sorter sorter = new TextFileSorter(config);
+
+    DataReader<byte[]> reader = new DataReader<byte[]>() {
+      @Override
+      public byte[] readNext() throws IOException {
+        if (!iter.hasNext()) {
+          return null;
+        }
+        return iter.next().toString().getBytes(Charsets.UTF_8);
+      }
+      @Override
+      public void close() throws IOException {}
+      @Override
+      public int estimateSizeInBytes(byte[] item) { return item.length; }
+    };
+
+    this.sortedIter = sorter.sort(reader);
+  }
+  
+  @Override
+  public boolean hasNext() {
+    return this.sortedIter.hasNext();
+  }
+  
+  @Override
+  public Path next() {
+    File f = new File(new String(this.sortedIter.next(), Charsets.UTF_8));
+    return f.toPath();
+  }  
+ }

--- a/warp10/src/main/java/io/warp10/continuum/Configuration.java
+++ b/warp10/src/main/java/io/warp10/continuum/Configuration.java
@@ -1190,6 +1190,11 @@ public class Configuration {
   public static final String DATALOG_PSK = "datalog.psk";
   
   /**
+   * Flag indicating whether or not to log forwarded requests.
+   */
+  public static final String DATALOG_LOGFORWARDED = "datalog.logforwarded";
+  
+  /**
    * Configuration key to modify the datalog header
    */
   public static final String HTTP_HEADER_DATALOG = "http.header.datalog";
@@ -1210,6 +1215,16 @@ public class Configuration {
    */
   public static final String DATALOG_FORWARDER_DSTDIR = "datalog.forwarder.dstdir";
   
+  /**
+   * Flag used to indicate that forwarded requests should be deleted instead of moved.
+   */
+  public static final String DATALOG_FORWARDER_DELETEFORWARDED = "datalog.forwarder.deleteforwarded";
+
+  /**
+   * Flag used to indicate that ignored requests should be deleted instead of moved.
+   */
+  public static final String DATALOG_FORWARDER_DELETEIGNORED = "datalog.forwarder.deleteignored";
+
   /**
    * Delay between directory scans (in ms)
    */

--- a/warp10/src/main/java/io/warp10/continuum/Configuration.java
+++ b/warp10/src/main/java/io/warp10/continuum/Configuration.java
@@ -1176,12 +1176,52 @@ public class Configuration {
   /**
    * Directory where data requests should be logged. This directory should be in 700 to protect sensitive token infos.
    */
-  public static final String STANDALONE_DATALOG_DIR = "standalone.datalog.dir";
+  public static final String DATALOG_DIR = "datalog.dir";
   
   /**
    * Optional key to encrypt the token in the file name used for datalogging
    */
-  public static final String STANDALONE_DATALOG_AES = "standalone.datalog.aes";
+  public static final String DATALOG_AES = "datalog.aes";
+  
+  /**
+   * Directory where successfully forwarded files will be moved
+   */
+  public static final String DATALOG_FORWARDER_DIR = "datalog.forwarder.dir";
+  
+  /**
+   * Delay between directory scans (in ms)
+   */
+  public static final String DATALOG_FORWARDER_PERIOD = "datalog.forwarder.period";
+  
+  /**
+   * Set to 'true' to compress forwarded update/meta requests
+   */
+  public static final String DATALOG_FORWARDER_COMPRESS = "datalog.forwarder.compress";
+  
+  /**
+   * Number of threads to spawn to handle datalog actions
+   */
+  public static final String DATALOG_FORWARDER_NTHREADS = "datalog.forwarder.nthreads";
+  
+  /**
+   * Header to use when specifying the token
+   */
+  public static final String DATALOG_FORWARDER_TOKENHEADER = "datalog.forwarder.tokenheader";
+  
+  /**
+   * Endpoint to use when forwarding UPDATE actions
+   */
+  public static final String DATALOG_FORWARDER_ENDPOINT_UPDATE = "datalog.forwarder.endpoint.update";
+  
+  /**
+   * Endpoint to use when forwarding DELETE actions
+   */  
+  public static final String DATALOG_FORWARDER_ENDPOINT_DELETE = "datalog.forwarder.endpoint.delete";
+  
+  /**
+   * Endpoint to use when forwarding META actions
+   */
+  public static final String DATALOG_FORWARDER_ENDPOINT_META = "datalog.forwarder.endpoint.meta";
   
   /**
    * Set to 'true' to indicate the instance will use memory only for storage. This type of instance is non persistent.

--- a/warp10/src/main/java/io/warp10/continuum/Configuration.java
+++ b/warp10/src/main/java/io/warp10/continuum/Configuration.java
@@ -1179,9 +1179,26 @@ public class Configuration {
   public static final String DATALOG_DIR = "datalog.dir";
   
   /**
-   * Optional key to encrypt the token in the file name used for datalogging
+   * Id of this datalog node. The id will be used in the file name and will be passed down to child nodes via
+   * a header.
    */
-  public static final String DATALOG_AES = "datalog.aes";
+  public static final String DATALOG_ID = "datalog.id";
+  
+  /**
+   * Pre-shared AES key to wrap datalog.id and datalog.timestamp header values
+   */
+  public static final String DATALOG_PSK = "datalog.psk";
+  
+  /**
+   * Configuration key to modify the datalog header
+   */
+  public static final String HTTP_HEADER_DATALOG = "http.header.datalog";
+  
+  /**
+   * Comma separated list of ids which should be ignored by the forwarder. This is to prevent loops from
+   * forming.
+   */
+  public static final String DATALOG_FORWARDER_NOFORWARD = "datalog.forwarder.noforward";
   
   /**
    * Directory where successfully forwarded files will be moved
@@ -1202,11 +1219,6 @@ public class Configuration {
    * Number of threads to spawn to handle datalog actions
    */
   public static final String DATALOG_FORWARDER_NTHREADS = "datalog.forwarder.nthreads";
-  
-  /**
-   * Header to use when specifying the token
-   */
-  public static final String DATALOG_FORWARDER_TOKENHEADER = "datalog.forwarder.tokenheader";
   
   /**
    * Endpoint to use when forwarding UPDATE actions

--- a/warp10/src/main/java/io/warp10/continuum/Configuration.java
+++ b/warp10/src/main/java/io/warp10/continuum/Configuration.java
@@ -1216,6 +1216,12 @@ public class Configuration {
   public static final String DATALOG_FORWARDER_COMPRESS = "datalog.forwarder.compress";
   
   /**
+   * Set to 'true' to act as a regular client when forwarding actions. Otherwise the datalog request will be forwarded.
+   * This MUST be set to 'true' when forwarding to a distributed version of Warp 10.
+   */
+  public static final String DATALOG_FORWARDER_ACTASCLIENT = "datalog.forwarder.actasclient";
+  
+  /**
    * Number of threads to spawn to handle datalog actions
    */
   public static final String DATALOG_FORWARDER_NTHREADS = "datalog.forwarder.nthreads";

--- a/warp10/src/main/java/io/warp10/continuum/Configuration.java
+++ b/warp10/src/main/java/io/warp10/continuum/Configuration.java
@@ -1201,9 +1201,14 @@ public class Configuration {
   public static final String DATALOG_FORWARDER_IGNORED = "datalog.forwarder.ignored";
   
   /**
+   * Directory from which to read the datalog files to forward
+   */
+  public static final String DATALOG_FORWARDER_SRCDIR = "datalog.forwarder.srcdir";
+  
+  /**
    * Directory where successfully forwarded files will be moved
    */
-  public static final String DATALOG_FORWARDER_DIR = "datalog.forwarder.dir";
+  public static final String DATALOG_FORWARDER_DSTDIR = "datalog.forwarder.dstdir";
   
   /**
    * Delay between directory scans (in ms)

--- a/warp10/src/main/java/io/warp10/continuum/Configuration.java
+++ b/warp10/src/main/java/io/warp10/continuum/Configuration.java
@@ -1198,7 +1198,7 @@ public class Configuration {
    * Comma separated list of ids which should be ignored by the forwarder. This is to prevent loops from
    * forming.
    */
-  public static final String DATALOG_FORWARDER_NOFORWARD = "datalog.forwarder.noforward";
+  public static final String DATALOG_FORWARDER_IGNORED = "datalog.forwarder.ignored";
   
   /**
    * Directory where successfully forwarded files will be moved

--- a/warp10/src/main/java/io/warp10/continuum/ingress/DatalogForwarder.java
+++ b/warp10/src/main/java/io/warp10/continuum/ingress/DatalogForwarder.java
@@ -407,7 +407,7 @@ public class DatalogForwarder extends Thread {
   
   public DatalogForwarder(KeyStore keystore, Properties properties) throws Exception {
     
-    this.rootdir = new File(properties.getProperty(Configuration.DATALOG_DIR)).toPath();
+    this.rootdir = new File(properties.getProperty(Configuration.DATALOG_FORWARDER_SRCDIR)).toPath();
     
     if (properties.containsKey(Configuration.DATALOG_PSK)) {
       this.datalogPSK = keystore.decodeKey(properties.getProperty(Configuration.DATALOG_PSK));
@@ -431,11 +431,11 @@ public class DatalogForwarder extends Thread {
       }
     }
     
-    if (!properties.containsKey(Configuration.DATALOG_FORWARDER_DIR)) {
-      throw new RuntimeException("Datalog forwarder target directory (" +  Configuration.DATALOG_FORWARDER_DIR + ") not set.");
+    if (!properties.containsKey(Configuration.DATALOG_FORWARDER_DSTDIR)) {
+      throw new RuntimeException("Datalog forwarder target directory (" +  Configuration.DATALOG_FORWARDER_DSTDIR + ") not set.");
     }
 
-    this.targetDir = new File(properties.getProperty(Configuration.DATALOG_FORWARDER_DIR));
+    this.targetDir = new File(properties.getProperty(Configuration.DATALOG_FORWARDER_DSTDIR));
 
     if (!this.targetDir.isDirectory()) {
       throw new RuntimeException("Invalid datalog forwarder target directory.");

--- a/warp10/src/main/java/io/warp10/continuum/ingress/DatalogForwarder.java
+++ b/warp10/src/main/java/io/warp10/continuum/ingress/DatalogForwarder.java
@@ -1,0 +1,490 @@
+package io.warp10.continuum.ingress;
+
+import io.warp10.continuum.Configuration;
+import io.warp10.continuum.store.Constants;
+import io.warp10.crypto.CryptoUtils;
+import io.warp10.crypto.KeyStore;
+import io.warp10.crypto.OrderPreservingBase64;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Iterator;
+import java.util.Properties;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.locks.LockSupport;
+import java.util.zip.GZIPOutputStream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Charsets;
+
+/**
+ * Forward UPDATA/META/DELETE requests to another Warp 10 instance
+ */
+public class DatalogForwarder extends Thread {
+  
+  private static final Logger LOG = LoggerFactory.getLogger(DatalogForwarder.class);
+  
+  public static final String DONE_SUFFIX = ".done";
+  
+  /**
+   * Queues to forward datalog actions according to token
+   */
+  private final LinkedBlockingQueue<DatalogAction>[] queues;
+  
+  private final String tokenHeader;
+  
+  private final Path rootdir;
+  
+  private final byte[] aesKey;
+  
+  /**
+   * URL for the UPDATE endpoint
+   */
+  private final URL updateUrl;
+
+  /**
+   * URL for the DELETE endpoint
+   */
+  private final URL deleteUrl;
+  
+  /**
+   * URL for the META endpoint
+   */
+  private final URL metaUrl;
+  
+  /**
+   * Target directory where processed files are moved
+   */
+  private final File targetDir;
+  
+  /**
+   * Period between directory scans
+   */
+  private final long period;
+  
+  /**
+   * Should we compress update/meta requests we forward
+   */
+  private final boolean compress;
+  
+  private static final String DEFAULT_PERIOD = "1000";
+  
+  private static enum DatalogActionType {
+    UPDATE,
+    DELETE,
+    META
+  }
+  
+  private static final class DatalogAction {
+    private DatalogActionType type;
+    private String token;
+    private File file;
+  }
+  
+  private static final class DatalogForwarderWorker extends Thread {
+
+    private final LinkedBlockingQueue<DatalogAction> queue;
+    
+    private final DatalogForwarder forwarder;
+    
+    public DatalogForwarderWorker(DatalogForwarder forwarder, LinkedBlockingQueue<DatalogAction> queue) {
+      this.queue = queue;
+      this.forwarder = forwarder;
+      this.setDaemon(true);
+      this.setName("[Datalog Forwarder Worker]");
+      this.start();
+    }
+    
+    @Override
+    public void run() {
+      
+      DatalogAction action = null;
+      
+      while(true) {
+        action = queue.peek();
+        
+        if (null == action) {
+          LockSupport.parkNanos(100000000L);
+          continue;
+        }
+        
+        switch (action.type) {
+          case DELETE:
+            if (!doDelete(action)) {
+              continue;
+            }
+            break;
+          case META:
+            if (!doMeta(action)) {
+              continue;
+            }
+            break;
+          case UPDATE:
+            if (!doUpdate(action)) {
+              continue;
+            }
+            break;
+        }
+        
+        //
+        // Move the file to our target directory and remove the action from the queue as we forwarded it successfully
+        //
+        
+        if (!action.file.renameTo(new File(this.forwarder.targetDir, action.file.getName()))) {
+          continue;
+        }
+        
+        queue.poll();
+      }
+    }
+    
+    private boolean doUpdate(DatalogAction action) {
+      if (!DatalogActionType.UPDATE.equals(action.type)) {
+        return false;
+      }
+      
+      BufferedReader br = null;
+
+      HttpURLConnection conn = null;
+      
+      try {
+        br = new BufferedReader(new FileReader(action.file));
+        
+        conn = (HttpURLConnection) forwarder.updateUrl.openConnection();
+        
+        conn.setDoOutput(true);
+        conn.setDoInput(true);
+        conn.setRequestMethod("POST");
+        conn.setRequestProperty(forwarder.tokenHeader, action.token);
+        
+        if (forwarder.compress) {
+          conn.setRequestProperty("Content-Type", "application/gzip");
+        }
+        
+        conn.setChunkedStreamingMode(16384);
+        conn.connect();
+        
+        OutputStream os = conn.getOutputStream();
+        
+        OutputStream out = null;
+        
+        if (forwarder.compress) {
+          out = new GZIPOutputStream(os);
+        } else {
+          out = os;
+        }
+        
+        PrintWriter pw = new PrintWriter(out);
+                
+        while(true) {
+          String line = br.readLine();
+          if (null == line) {
+            break;
+          }
+          pw.println(line);
+        }
+        
+        pw.close();
+
+        br.close();
+        
+        //
+        // Update was successful, delete all batchfiles
+        //
+        
+        boolean success = 200 == conn.getResponseCode();
+        
+        if (!success) {
+          LOG.error(conn.getResponseMessage());
+        }
+        
+        conn.disconnect();
+        conn = null;
+
+        return success;
+      } catch (IOException ioe){
+        return false;
+      } finally {
+        if (null != conn) {
+          conn.disconnect();
+        }
+        if (null != br) { try { br.close(); } catch (IOException ioe) {} }
+      }
+    }
+    
+    private boolean doDelete(DatalogAction action) {
+      if (!DatalogActionType.DELETE.equals(action.type)) {
+        return false;
+      }
+      
+      BufferedReader br = null;
+
+      HttpURLConnection conn = null;
+      
+      try {        
+        br = new BufferedReader(new FileReader(action.file));
+        
+        String qs = br.readLine();
+        
+        if (null == qs) {
+          return true;
+        }
+        
+        URL urlAndQS = new URL(forwarder.deleteUrl.toString() + "?" + qs);
+        
+        conn = (HttpURLConnection) urlAndQS.openConnection();
+        
+        conn.setDoInput(true);
+        conn.setRequestMethod("GET");
+        conn.setRequestProperty(forwarder.tokenHeader, action.token);        
+        conn.setChunkedStreamingMode(16384);
+        conn.connect();
+        
+        br.close();
+        
+        //
+        // Update was successful, delete all batchfiles
+        //
+        
+        boolean success = 200 == conn.getResponseCode();
+        
+        if (!success) {
+          LOG.error(conn.getResponseMessage());
+        }
+        
+        conn.disconnect();
+        conn = null;
+
+        return success;
+      } catch (IOException ioe){
+        return false;
+      } finally {
+        if (null != conn) {
+          conn.disconnect();
+        }
+        if (null != br) { try { br.close(); } catch (IOException ioe) {} }
+      }
+    }
+    
+    private boolean doMeta(DatalogAction action) {
+      if (!DatalogActionType.META.equals(action.type)) {
+        return false;
+      }
+      
+      BufferedReader br = null;
+
+      HttpURLConnection conn = null;
+      
+      try {
+        br = new BufferedReader(new FileReader(action.file));
+        
+        conn = (HttpURLConnection) forwarder.metaUrl.openConnection();
+        
+        conn.setDoOutput(true);
+        conn.setDoInput(true);
+        conn.setRequestMethod("POST");
+        conn.setRequestProperty(forwarder.tokenHeader, action.token);
+        
+        if (forwarder.compress) {
+          conn.setRequestProperty("Content-Type", "application/gzip");
+        }
+        
+        conn.setChunkedStreamingMode(16384);
+        conn.connect();
+        
+        OutputStream os = conn.getOutputStream();
+        
+        OutputStream out = null;
+        
+        if (forwarder.compress) {
+          out = new GZIPOutputStream(os);
+        } else {
+          out = os;
+        }
+        
+        PrintWriter pw = new PrintWriter(out);
+                
+        while(true) {
+          String line = br.readLine();
+          if (null == line) {
+            break;
+          }
+          pw.println(line);
+        }
+        
+        pw.close();
+
+        br.close();
+        
+        //
+        // Update was successful, delete all batchfiles
+        //
+        
+        boolean success = 200 == conn.getResponseCode();
+        
+        if (!success) {
+          LOG.error(conn.getResponseMessage());
+        }
+
+        conn.disconnect();
+        conn = null;
+
+        return success;
+      } catch (IOException ioe){
+        return false;
+      } finally {
+        if (null != conn) {
+          conn.disconnect();
+        }
+        if (null != br) { try { br.close(); } catch (IOException ioe) {} }
+      }
+    }
+    
+  }
+  
+  public DatalogForwarder(KeyStore keystore, Properties properties) throws Exception {
+    
+    this.rootdir = new File(properties.getProperty(Configuration.DATALOG_DIR)).toPath();
+    
+    if (properties.containsKey(Configuration.DATALOG_AES)) {
+      this.aesKey = keystore.decodeKey(properties.getProperty(Configuration.DATALOG_AES));
+    } else {
+      this.aesKey = null;
+    }
+    
+    this.period = Long.parseLong(properties.getProperty(Configuration.DATALOG_FORWARDER_PERIOD, DEFAULT_PERIOD));
+    
+    this.compress = "true".equals(properties.getProperty(Configuration.DATALOG_FORWARDER_COMPRESS));
+    
+    if (!properties.containsKey(Configuration.DATALOG_FORWARDER_DIR)) {
+      throw new RuntimeException("Datalog forwarder target directory (" +  Configuration.DATALOG_FORWARDER_DIR + ") not set.");
+    }
+
+    this.targetDir = new File(properties.getProperty(Configuration.DATALOG_FORWARDER_DIR));
+
+    if (!this.targetDir.isDirectory()) {
+      throw new RuntimeException("Invalid datalog forwarder target directory.");
+    }
+    
+    int nthreads = Integer.parseInt(properties.getProperty(Configuration.DATALOG_FORWARDER_NTHREADS, "1"));
+    
+    this.tokenHeader = properties.getProperty(Configuration.DATALOG_FORWARDER_TOKENHEADER, Constants.HTTP_HEADER_TOKEN_DEFAULT);
+    
+    
+    if (!properties.containsKey(Configuration.DATALOG_FORWARDER_ENDPOINT_UPDATE)) {
+      throw new RuntimeException("Missing UPDATE endpoint.");
+    }
+    this.updateUrl = new URL(properties.getProperty(Configuration.DATALOG_FORWARDER_ENDPOINT_UPDATE));
+
+    if (!properties.containsKey(Configuration.DATALOG_FORWARDER_ENDPOINT_DELETE)) {
+      throw new RuntimeException("Missing DELETE endpoint.");
+    }
+    this.deleteUrl = new URL(properties.getProperty(Configuration.DATALOG_FORWARDER_ENDPOINT_DELETE));
+
+    if (!properties.containsKey(Configuration.DATALOG_FORWARDER_ENDPOINT_META)) {
+      throw new RuntimeException("Missing META endpoint.");
+    }
+    this.metaUrl = new URL(properties.getProperty(Configuration.DATALOG_FORWARDER_ENDPOINT_META));
+
+    queues = new LinkedBlockingQueue[nthreads];
+    
+    for (int i = 0; i < nthreads; i++) {
+      queues[i] = new LinkedBlockingQueue<DatalogAction>(64);
+      DatalogForwarderWorker forwarder = new DatalogForwarderWorker(this, queues[i]);
+    }
+    
+    this.setName("[Datalog Forwarder]");
+    this.setDaemon(true);
+    this.start();
+  }
+  
+  @Override
+  public void run() {
+    while (true) {
+      //
+      // Scan the datalog directory
+      //
+      
+      DirectoryStream<Path> ds = null;
+      
+      try {
+        ds = Files.newDirectoryStream(rootdir, "*" + DONE_SUFFIX);        
+      } catch (IOException ioe) {
+        LOG.error("Error while getting file list for directory " + rootdir, ioe);
+        LockSupport.parkNanos(1000000000L);
+        continue;
+      }
+      
+      Iterator<Path> iter = ds.iterator();
+      
+      while(iter.hasNext()) {
+        //
+        // Extract timestamp/action/token
+        //
+        
+        Path p = iter.next();
+        
+        String[] subtokens = p.getFileName().toString().split("-");
+        
+        //
+        // Ignore files which do not have the correct name
+        //
+        
+        if (3 != subtokens.length) {
+          continue;
+        }
+        
+        long ts = Long.parseLong(subtokens[0], 16);
+        DatalogActionType type = DatalogActionType.valueOf(subtokens[1]);
+        String token = subtokens[2].substring(0, subtokens[2].length() - DONE_SUFFIX.length());
+        
+        DatalogAction action = new DatalogAction();
+        
+        //
+        // extract token
+        //
+
+        byte[] tokenbytes = OrderPreservingBase64.decode(token.getBytes(Charsets.US_ASCII));
+        
+        if (null != this.aesKey) {
+          tokenbytes = CryptoUtils.unwrap(this.aesKey, tokenbytes);
+        }
+        
+        token = new String(tokenbytes, Charsets.ISO_8859_1);
+        action.token = token;
+        action.type = type;
+        action.file = p.toFile();
+        
+        //
+        // Dispatch the action to the correct queue according to the token
+        //
+        
+        int q = token.hashCode() % queues.length;
+        
+        try {
+          queues[q].put(action);
+        } catch (InterruptedException ie) {
+          break;
+        }                                
+      }
+      
+      try {
+        ds.close();
+      } catch (IOException ioe) {        
+      }
+      
+      LockSupport.parkNanos(this.period * 1000000L);
+    }
+  }
+}

--- a/warp10/src/main/java/io/warp10/continuum/ingress/DatalogForwarder.java
+++ b/warp10/src/main/java/io/warp10/continuum/ingress/DatalogForwarder.java
@@ -531,6 +531,8 @@ public class DatalogForwarder extends Thread {
         //
         
         if (this.ignoredIds.contains(id)) {
+          // File should be ignored, move it directly to the target directory
+          action.file.renameTo(new File(this.targetDir, action.file.getName()));
           continue;
         }
         

--- a/warp10/src/main/java/io/warp10/continuum/ingress/DatalogForwarder.java
+++ b/warp10/src/main/java/io/warp10/continuum/ingress/DatalogForwarder.java
@@ -16,6 +16,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintWriter;
+import java.math.BigInteger;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.file.DirectoryStream;
@@ -452,9 +453,11 @@ public class DatalogForwarder extends Thread {
         
         Path p = iter.next();
         String filename = p.getFileName().toString();
+        String[] subtokens = filename.split("=");
         
-        long ts = Long.parseLong(filename.substring(0, filename.length() - DATALOG_SUFFIX.length()));
-                
+        long ts = new BigInteger(subtokens[0], 16).longValue();
+        String id = subtokens[1].substring(0, subtokens[1].length() - DATALOG_SUFFIX.length());
+        
         DatalogAction action = new DatalogAction();
         
         action.file = p.toFile();
@@ -493,12 +496,17 @@ public class DatalogForwarder extends Thread {
         action.request = dr;
         
         //
-        // Check that timestamp matches
+        // Check that timestamp and id match
         //
         
         if (ts != dr.getTimestamp()) {
           LOG.error("Datalog Request '" + action.file + "' has a timestamp which differs from that of its file, timestamp is 0x" + Long.toHexString(dr.getTimestamp()));
           break;
+        }
+        
+        if (!id.equals(dr.getId())) {
+          LOG.error("Datalog Request '" + action.file + "' has an id which differs from that of its file, id is " + dr.getId());
+          break;          
         }
         
         //

--- a/warp10/src/main/java/io/warp10/continuum/ingress/DatalogForwarder.java
+++ b/warp10/src/main/java/io/warp10/continuum/ingress/DatalogForwarder.java
@@ -1,5 +1,6 @@
 package io.warp10.continuum.ingress;
 
+import io.warp10.SortedPathIterator;
 import io.warp10.continuum.Configuration;
 import io.warp10.continuum.Tokens;
 import io.warp10.continuum.store.Constants;
@@ -487,7 +488,15 @@ public class DatalogForwarder extends Thread {
         continue;
       }
       
-      Iterator<Path> iter = ds.iterator();
+      Iterator<Path> iter = null;
+      
+      try {
+        iter = new SortedPathIterator(ds.iterator());
+      } catch (IOException ioe) {
+        LOG.error("Error while getting path iterator.");
+        LockSupport.parkNanos(1000000000L);
+        continue;
+      }
       
       while(iter.hasNext()) {
         //

--- a/warp10/src/main/java/io/warp10/continuum/ingress/DatalogForwarder.java
+++ b/warp10/src/main/java/io/warp10/continuum/ingress/DatalogForwarder.java
@@ -456,7 +456,7 @@ public class DatalogForwarder extends Thread {
         String[] subtokens = filename.split("=");
         
         long ts = new BigInteger(subtokens[0], 16).longValue();
-        String id = subtokens[1].substring(0, subtokens[1].length() - DATALOG_SUFFIX.length());
+        String id = new String(OrderPreservingBase64.decode(subtokens[1].substring(0, subtokens[1].length() - DATALOG_SUFFIX.length()).getBytes(Charsets.US_ASCII)), Charsets.UTF_8);
         
         DatalogAction action = new DatalogAction();
         

--- a/warp10/src/main/java/io/warp10/continuum/ingress/DatalogForwarder.java
+++ b/warp10/src/main/java/io/warp10/continuum/ingress/DatalogForwarder.java
@@ -266,32 +266,18 @@ public class DatalogForwarder extends Thread {
         return false;
       }
       
-      BufferedReader br = null;
-
       HttpURLConnection conn = null;
       
-      try {        
-        br = new BufferedReader(new FileReader(action.file));
-        
-        String discardReq = br.readLine();
-        String qs = br.readLine();
-        
-        if (null == qs) {
-          return true;
-        }
-        
-        URL urlAndQS = new URL(forwarder.deleteUrl.toString() + "?" + qs);
+      try {
+        URL urlAndQS = new URL(forwarder.deleteUrl.toString() + "?" + action.request.getDeleteQueryString());
         
         conn = (HttpURLConnection) urlAndQS.openConnection();
         
         conn.setDoInput(true);
         conn.setRequestMethod("GET");
         conn.setRequestProperty(Constants.getHeader(Configuration.HTTP_HEADER_DATALOG), action.encodedRequest);
-        conn.setChunkedStreamingMode(16384);
         conn.connect();
-        
-        br.close();
-        
+                
         //
         // Update was successful, delete all batchfiles
         //
@@ -312,7 +298,6 @@ public class DatalogForwarder extends Thread {
         if (null != conn) {
           conn.disconnect();
         }
-        if (null != br) { try { br.close(); } catch (IOException ioe) {} }
       }
     }
     
@@ -500,7 +485,7 @@ public class DatalogForwarder extends Thread {
         String[] subtokens = filename.split("-");
         
         long ts = new BigInteger(subtokens[0], 16).longValue();
-        String id = subtokens[1].substring(0, subtokens[1].length() - DATALOG_SUFFIX.length());
+        String id = subtokens[1];
         
         DatalogAction action = new DatalogAction();
         

--- a/warp10/src/main/java/io/warp10/continuum/ingress/DatalogForwarder.java
+++ b/warp10/src/main/java/io/warp10/continuum/ingress/DatalogForwarder.java
@@ -42,7 +42,7 @@ public class DatalogForwarder extends Thread {
   
   private static final Logger LOG = LoggerFactory.getLogger(DatalogForwarder.class);
   
-  public static final String DATALOG_SUFFIX = ".done";
+  public static final String DATALOG_SUFFIX = ".datalog";
   
   /**
    * Queues to forward datalog actions according to token

--- a/warp10/src/main/java/io/warp10/continuum/sensision/SensisionConstants.java
+++ b/warp10/src/main/java/io/warp10/continuum/sensision/SensisionConstants.java
@@ -31,6 +31,31 @@ public class SensisionConstants {
   //
   
   /**
+   * Number of datalog requests which were forwarded successfully
+   */
+  public static final String CLASS_WARP_DATALOG_FORWARDER_REQUESTS_FORWARDED = "warp.datalog,forwarder.requests.forwarded";
+
+  /**
+   * Number of datalog requests which failed to be forwarded
+   */
+  public static final String CLASS_WARP_DATALOG_FORWARDER_REQUESTS_FAILED = "warp.datalog.forwarder.requests.failed";
+
+  /**
+   * Number of datalog requests which were ignored
+   */
+  public static final String CLASS_WARP_DATALOG_FORWARDER_REQUESTS_IGNORED = "warp.datalog.forwarder.requests.ignored";
+
+  /**
+   * Number of datalog requests logged
+   */
+  public static final String CLASS_WARP_DATALOG_REQUESTS_LOGGED = "warp.datalog.requests.logged";
+
+  /**
+   * Number of datalog requests received
+   */
+  public static final String CLASS_WARP_DATALOG_REQUESTS_RECEIVED = "warp.datalog.requests.received";
+
+  /**
    * Number of errors encountered when fetching data, might be an indication of problem related to hbase
    */
   public static final String CLASS_WARP_FETCH_ERRORS = "warp.fetch.errors";
@@ -1331,6 +1356,11 @@ public class SensisionConstants {
    */
   public static final String SENSISION_LABEL_TYPE = "type";
 
+  /**
+   * Id of something
+   */
+  public static final String SENSISION_LABEL_ID = "id";
+  
   /**
    * Component
    */

--- a/warp10/src/main/java/io/warp10/continuum/store/Constants.java
+++ b/warp10/src/main/java/io/warp10/continuum/store/Constants.java
@@ -181,9 +181,19 @@ public class Constants {
   public static String HTTP_HEADER_DIRECTORY_SIGNATURE_DEFAULT = "X-Warp10-Directory-Signature";
 
   /**
-   * Name of header specifying the name of the symbol in which to expose the reques headers
+   * Name of header specifying the name of the symbol in which to expose the request headers
    */
   public static String HTTP_HEADER_EXPOSE_HEADERS_DEFAULT = "X-Warp10-ExposeHeaders";
+  
+  /**
+   * Name of header containing the wrapped Datalog request
+   */
+  public static String HTTP_HEADER_DATALOG_DEFAULT = "X-Warp10-Datalog";
+  
+  public static String DATALOG_UPDATE = "UPDATE";
+  public static String DATALOG_ARCHIVE = "ARCHIVE";
+  public static String DATALOG_META = "META";
+  public static String DATALOG_DELETE = "DELETE";
   
   /**
    * Empty column qualifier for HBase writes
@@ -382,6 +392,7 @@ public class Constants {
     HEADERS.put(Configuration.HTTP_HEADER_UPDATE_SIGNATURE, props.getProperty(Configuration.HTTP_HEADER_UPDATE_SIGNATURE, HTTP_HEADER_UPDATE_SIGNATURE_DEFAULT));
     HEADERS.put(Configuration.HTTP_HEADER_DIRECTORY_SIGNATURE, props.getProperty(Configuration.HTTP_HEADER_DIRECTORY_SIGNATURE, HTTP_HEADER_DIRECTORY_SIGNATURE_DEFAULT));
     HEADERS.put(Configuration.HTTP_HEADER_EXPOSE_HEADERS, props.getProperty(Configuration.HTTP_HEADER_EXPOSE_HEADERS, HTTP_HEADER_EXPOSE_HEADERS_DEFAULT));
+    HEADERS.put(Configuration.HTTP_HEADER_DATALOG, props.getProperty(Configuration.HTTP_HEADER_DATALOG, HTTP_HEADER_DATALOG_DEFAULT));
   }
   
   public static String getHeader(String name) {

--- a/warp10/src/main/java/io/warp10/standalone/StandaloneDeleteHandler.java
+++ b/warp10/src/main/java/io/warp10/standalone/StandaloneDeleteHandler.java
@@ -251,7 +251,9 @@ public class StandaloneDeleteHandler extends AbstractHandler {
       StringBuilder sb = new StringBuilder();
       sb.append(Long.toHexString(nanos));
       sb.insert(0, "0000000000000000", 0, 16 - sb.length());
-      
+      sb.append("-");
+      sb.append(new String(OrderPreservingBase64.encode(datalogId.getBytes(Charsets.UTF_8)), Charsets.US_ASCII));
+
       if (null == dr) {
         dr = new DatalogRequest();
         dr.setTimestamp(nanos);

--- a/warp10/src/main/java/io/warp10/standalone/StandaloneDeleteHandler.java
+++ b/warp10/src/main/java/io/warp10/standalone/StandaloneDeleteHandler.java
@@ -24,6 +24,7 @@ import io.warp10.continuum.Tokens;
 import io.warp10.continuum.egress.EgressExecHandler;
 import io.warp10.continuum.egress.EgressFetchHandler;
 import io.warp10.continuum.gts.GTSHelper;
+import io.warp10.continuum.ingress.DatalogForwarder;
 import io.warp10.continuum.sensision.SensisionConstants;
 import io.warp10.continuum.store.Constants;
 import io.warp10.continuum.store.StoreClient;
@@ -99,8 +100,8 @@ public class StandaloneDeleteHandler extends AbstractHandler {
     
     Properties props = WarpConfig.getProperties();
     
-    if (props.containsKey(Configuration.STANDALONE_DATALOG_DIR)) {
-      File dir = new File(props.getProperty(Configuration.STANDALONE_DATALOG_DIR));
+    if (props.containsKey(Configuration.DATALOG_DIR)) {
+      File dir = new File(props.getProperty(Configuration.DATALOG_DIR));
       
       if (!dir.exists()) {
         throw new RuntimeException("Data logging target '" + dir + "' does not exist.");
@@ -113,8 +114,8 @@ public class StandaloneDeleteHandler extends AbstractHandler {
       loggingDir = null;
     }
     
-    if (props.containsKey(Configuration.STANDALONE_DATALOG_AES)) {
-      this.tokenWrappingKey = this.keyStore.decodeKey(props.getProperty(Configuration.STANDALONE_DATALOG_AES));
+    if (props.containsKey(Configuration.DATALOG_AES)) {
+      this.tokenWrappingKey = this.keyStore.decodeKey(props.getProperty(Configuration.DATALOG_AES));
     } else {
       this.tokenWrappingKey = null;
     }
@@ -379,7 +380,7 @@ public class StandaloneDeleteHandler extends AbstractHandler {
     } finally {
       if (null != loggingWriter) {
         loggingWriter.close();
-        loggingFile.renameTo(new File(loggingFile.getAbsolutePath() + ".done"));
+        loggingFile.renameTo(new File(loggingFile.getAbsolutePath() + DatalogForwarder.DONE_SUFFIX));
       }      
 
       Sensision.update(SensisionConstants.SENSISION_CLASS_CONTINUUM_STANDALONE_DELETE_REQUESTS, sensisionLabels, 1);

--- a/warp10/src/main/java/io/warp10/standalone/StandaloneDeleteHandler.java
+++ b/warp10/src/main/java/io/warp10/standalone/StandaloneDeleteHandler.java
@@ -252,7 +252,11 @@ public class StandaloneDeleteHandler extends AbstractHandler {
       sb.append(Long.toHexString(nanos));
       sb.insert(0, "0000000000000000", 0, 16 - sb.length());
       sb.append("-");
-      sb.append(new String(OrderPreservingBase64.encode(datalogId.getBytes(Charsets.UTF_8)), Charsets.US_ASCII));
+      if (null != dr) {
+        sb.append(dr.getId());
+      } else {
+        sb.append(datalogId);
+      }
 
       if (null == dr) {
         dr = new DatalogRequest();

--- a/warp10/src/main/java/io/warp10/standalone/StandaloneDeleteHandler.java
+++ b/warp10/src/main/java/io/warp10/standalone/StandaloneDeleteHandler.java
@@ -188,6 +188,11 @@ public class StandaloneDeleteHandler extends AbstractHandler {
         throw new IOException();
       }
       
+      Map<String,String> labels = new HashMap<String,String>();
+      labels.put(SensisionConstants.SENSISION_LABEL_ID, new String(OrderPreservingBase64.decode(dr.getId().getBytes(Charsets.US_ASCII)), Charsets.UTF_8));
+      labels.put(SensisionConstants.SENSISION_LABEL_TYPE, dr.getType());
+      Sensision.update(SensisionConstants.CLASS_WARP_DATALOG_REQUESTS_RECEIVED, labels, 1);
+
       //
       // Check that the request query string matches the QS in the datalog request
       //

--- a/warp10/src/main/java/io/warp10/standalone/StandaloneDeleteHandler.java
+++ b/warp10/src/main/java/io/warp10/standalone/StandaloneDeleteHandler.java
@@ -476,6 +476,11 @@ public class StandaloneDeleteHandler extends AbstractHandler {
       throw e;
     } finally {
       if (null != loggingWriter) {
+        Map<String,String> labels = new HashMap<String,String>();
+        labels.put(SensisionConstants.SENSISION_LABEL_ID, new String(OrderPreservingBase64.decode(dr.getId().getBytes(Charsets.US_ASCII)), Charsets.UTF_8));
+        labels.put(SensisionConstants.SENSISION_LABEL_TYPE, dr.getType());
+        Sensision.update(SensisionConstants.CLASS_WARP_DATALOG_REQUESTS_LOGGED, labels, 1);
+
         loggingWriter.close();
         if (validated) {
           loggingFile.renameTo(new File(loggingFile.getAbsolutePath() + DatalogForwarder.DATALOG_SUFFIX));

--- a/warp10/src/main/java/io/warp10/standalone/StandaloneIngressHandler.java
+++ b/warp10/src/main/java/io/warp10/standalone/StandaloneIngressHandler.java
@@ -342,6 +342,8 @@ public class StandaloneIngressHandler extends AbstractHandler {
         StringBuilder sb = new StringBuilder();
         sb.append(Long.toHexString(nanos));
         sb.insert(0, "0000000000000000", 0, 16 - sb.length());
+        sb.append("-");
+        sb.append(new String(OrderPreservingBase64.encode(datalogId.getBytes(Charsets.UTF_8)), Charsets.US_ASCII));
         
         if (null == dr) {
           dr = new DatalogRequest();
@@ -687,7 +689,9 @@ public class StandaloneIngressHandler extends AbstractHandler {
       StringBuilder sb = new StringBuilder();
       sb.append(Long.toHexString(nanos));
       sb.insert(0, "0000000000000000", 0, 16 - sb.length());
-      
+      sb.append("-");
+      sb.append(new String(OrderPreservingBase64.encode(datalogId.getBytes(Charsets.UTF_8)), Charsets.US_ASCII));
+
       if (null == dr) {
         dr = new DatalogRequest();
         dr.setTimestamp(nanos);

--- a/warp10/src/main/java/io/warp10/standalone/StandaloneIngressHandler.java
+++ b/warp10/src/main/java/io/warp10/standalone/StandaloneIngressHandler.java
@@ -215,6 +215,11 @@ public class StandaloneIngressHandler extends AbstractHandler {
       }
       
       token = dr.getToken();
+      
+      Map<String,String> labels = new HashMap<String,String>();
+      labels.put(SensisionConstants.SENSISION_LABEL_ID, new String(OrderPreservingBase64.decode(dr.getId().getBytes(Charsets.US_ASCII)), Charsets.UTF_8));
+      labels.put(SensisionConstants.SENSISION_LABEL_TYPE, dr.getType());
+      Sensision.update(SensisionConstants.CLASS_WARP_DATALOG_REQUESTS_RECEIVED, labels, 1);
     }
 
     //
@@ -656,6 +661,11 @@ public class StandaloneIngressHandler extends AbstractHandler {
       } catch (TException te) {
         throw new IOException();
       }
+      
+      Map<String,String> labels = new HashMap<String,String>();
+      labels.put(SensisionConstants.SENSISION_LABEL_ID, new String(OrderPreservingBase64.decode(dr.getId().getBytes(Charsets.US_ASCII)), Charsets.UTF_8));
+      labels.put(SensisionConstants.SENSISION_LABEL_TYPE, dr.getType());
+      Sensision.update(SensisionConstants.CLASS_WARP_DATALOG_REQUESTS_RECEIVED, labels, 1);
     }
 
     //

--- a/warp10/src/main/java/io/warp10/standalone/StandaloneIngressHandler.java
+++ b/warp10/src/main/java/io/warp10/standalone/StandaloneIngressHandler.java
@@ -25,6 +25,7 @@ import io.warp10.continuum.Tokens;
 import io.warp10.continuum.WarpException;
 import io.warp10.continuum.gts.GTSEncoder;
 import io.warp10.continuum.gts.GTSHelper;
+import io.warp10.continuum.ingress.DatalogForwarder;
 import io.warp10.continuum.sensision.SensisionConstants;
 import io.warp10.continuum.store.Constants;
 import io.warp10.continuum.store.StoreClient;
@@ -104,8 +105,8 @@ public class StandaloneIngressHandler extends AbstractHandler {
     
     Properties props = WarpConfig.getProperties();
     
-    if (props.containsKey(Configuration.STANDALONE_DATALOG_DIR)) {
-      File dir = new File(props.getProperty(Configuration.STANDALONE_DATALOG_DIR));
+    if (props.containsKey(Configuration.DATALOG_DIR)) {
+      File dir = new File(props.getProperty(Configuration.DATALOG_DIR));
       
       if (!dir.exists()) {
         throw new RuntimeException("Data logging target '" + dir + "' does not exist.");
@@ -119,8 +120,8 @@ public class StandaloneIngressHandler extends AbstractHandler {
       loggingDir = null;
     }
     
-    if (props.containsKey(Configuration.STANDALONE_DATALOG_AES)) {
-      this.tokenWrappingKey = this.keyStore.decodeKey(props.getProperty(Configuration.STANDALONE_DATALOG_AES));
+    if (props.containsKey(Configuration.DATALOG_AES)) {
+      this.tokenWrappingKey = this.keyStore.decodeKey(props.getProperty(Configuration.DATALOG_AES));
     } else {
       this.tokenWrappingKey = null;
     }
@@ -477,7 +478,7 @@ public class StandaloneIngressHandler extends AbstractHandler {
             
       if (null != loggingWriter) {
         loggingWriter.close();
-        loggingFile.renameTo(new File(loggingFile.getAbsolutePath() + ".done"));
+        loggingFile.renameTo(new File(loggingFile.getAbsolutePath() + DatalogForwarder.DONE_SUFFIX));
       }
 
       //
@@ -651,7 +652,7 @@ public class StandaloneIngressHandler extends AbstractHandler {
     } finally {
       if (null != loggingWriter) {
         loggingWriter.close();
-        loggingFile.renameTo(new File(loggingFile.getAbsolutePath() + ".done"));
+        loggingFile.renameTo(new File(loggingFile.getAbsolutePath() + DatalogForwarder.DONE_SUFFIX));
       }      
     }
     

--- a/warp10/src/main/java/io/warp10/standalone/StandaloneIngressHandler.java
+++ b/warp10/src/main/java/io/warp10/standalone/StandaloneIngressHandler.java
@@ -61,6 +61,9 @@ import org.apache.thrift.TSerializer;
 import org.apache.thrift.protocol.TCompactProtocol;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+import org.joda.time.format.ISODateTimeFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -98,6 +101,8 @@ public class StandaloneIngressHandler extends AbstractHandler {
   private final File loggingDir;
   
   private final String datalogId;
+  
+  private final DateTimeFormatter dtf = DateTimeFormat.forPattern("yyyyMMdd'T'HHmmss.SSS").withZoneUTC();
   
   public StandaloneIngressHandler(KeyStore keystore, StandaloneDirectoryClient directoryClient, StoreClient storeClient) {
     this.keyStore = keystore;
@@ -348,6 +353,11 @@ public class StandaloneIngressHandler extends AbstractHandler {
         } else {
           sb.append(datalogId);
         }
+        
+        sb.append("-");
+        sb.append(dtf.print(nanos / 1000000L));
+        sb.append(Long.toString(1000000L + (nanos % 1000000L)).substring(1));
+        sb.append("Z");
         
         if (null == dr) {
           dr = new DatalogRequest();
@@ -700,6 +710,11 @@ public class StandaloneIngressHandler extends AbstractHandler {
         sb.append(datalogId);
       }
 
+      sb.append("-");
+      sb.append(dtf.print(nanos / 1000000L));
+      sb.append(Long.toString(1000000L + (nanos % 1000000L)).substring(1));
+      sb.append("Z");
+      
       if (null == dr) {
         dr = new DatalogRequest();
         dr.setTimestamp(nanos);

--- a/warp10/src/main/java/io/warp10/standalone/StandaloneIngressHandler.java
+++ b/warp10/src/main/java/io/warp10/standalone/StandaloneIngressHandler.java
@@ -26,6 +26,7 @@ import io.warp10.continuum.WarpException;
 import io.warp10.continuum.gts.GTSEncoder;
 import io.warp10.continuum.gts.GTSHelper;
 import io.warp10.continuum.ingress.DatalogForwarder;
+import io.warp10.continuum.ingress.DatalogForwarder.DatalogActionType;
 import io.warp10.continuum.sensision.SensisionConstants;
 import io.warp10.continuum.store.Constants;
 import io.warp10.continuum.store.StoreClient;
@@ -579,6 +580,11 @@ public class StandaloneIngressHandler extends AbstractHandler {
       }
             
       if (null != loggingWriter) {
+        Map<String,String> labels = new HashMap<String,String>();
+        labels.put(SensisionConstants.SENSISION_LABEL_ID, new String(OrderPreservingBase64.decode(dr.getId().getBytes(Charsets.US_ASCII)), Charsets.UTF_8));
+        labels.put(SensisionConstants.SENSISION_LABEL_TYPE, dr.getType());
+        Sensision.update(SensisionConstants.CLASS_WARP_DATALOG_REQUESTS_LOGGED, labels, 1);
+
         loggingWriter.close();
         loggingFile.renameTo(new File(loggingFile.getAbsolutePath() + DatalogForwarder.DATALOG_SUFFIX));
       }
@@ -819,6 +825,11 @@ public class StandaloneIngressHandler extends AbstractHandler {
       }      
     } finally {
       if (null != loggingWriter) {
+        Map<String,String> labels = new HashMap<String,String>();
+        labels.put(SensisionConstants.SENSISION_LABEL_ID, new String(OrderPreservingBase64.decode(dr.getId().getBytes(Charsets.US_ASCII)), Charsets.UTF_8));
+        labels.put(SensisionConstants.SENSISION_LABEL_TYPE, dr.getType());
+        Sensision.update(SensisionConstants.CLASS_WARP_DATALOG_REQUESTS_LOGGED, labels, 1);
+
         loggingWriter.close();
         loggingFile.renameTo(new File(loggingFile.getAbsolutePath() + DatalogForwarder.DATALOG_SUFFIX));
       }      

--- a/warp10/src/main/java/io/warp10/standalone/StandaloneIngressHandler.java
+++ b/warp10/src/main/java/io/warp10/standalone/StandaloneIngressHandler.java
@@ -343,7 +343,11 @@ public class StandaloneIngressHandler extends AbstractHandler {
         sb.append(Long.toHexString(nanos));
         sb.insert(0, "0000000000000000", 0, 16 - sb.length());
         sb.append("-");
-        sb.append(new String(OrderPreservingBase64.encode(datalogId.getBytes(Charsets.UTF_8)), Charsets.US_ASCII));
+        if (null != dr) {
+          sb.append(dr.getId());
+        } else {
+          sb.append(datalogId);
+        }
         
         if (null == dr) {
           dr = new DatalogRequest();
@@ -690,7 +694,11 @@ public class StandaloneIngressHandler extends AbstractHandler {
       sb.append(Long.toHexString(nanos));
       sb.insert(0, "0000000000000000", 0, 16 - sb.length());
       sb.append("-");
-      sb.append(new String(OrderPreservingBase64.encode(datalogId.getBytes(Charsets.UTF_8)), Charsets.US_ASCII));
+      if (null != dr) {
+        sb.append(dr.getId());
+      } else {
+        sb.append(datalogId);
+      }
 
       if (null == dr) {
         dr = new DatalogRequest();

--- a/warp10/src/main/java/io/warp10/standalone/StandaloneStreamUpdateHandler.java
+++ b/warp10/src/main/java/io/warp10/standalone/StandaloneStreamUpdateHandler.java
@@ -182,7 +182,8 @@ public class StandaloneStreamUpdateHandler extends WebSocketHandler.Simple {
           
           File loggingFile = null;   
           PrintWriter loggingWriter = null;
-
+          DatalogRequest dr = null;
+          
           try {
             GTSEncoder lastencoder = null;
             GTSEncoder encoder = null;
@@ -209,6 +210,11 @@ public class StandaloneStreamUpdateHandler extends WebSocketHandler.Simple {
                 //
                 
                 if (null != loggingWriter) {
+                  Map<String,String> labels = new HashMap<String,String>();
+                  labels.put(SensisionConstants.SENSISION_LABEL_ID, new String(OrderPreservingBase64.decode(dr.getId().getBytes(Charsets.US_ASCII)), Charsets.UTF_8));
+                  labels.put(SensisionConstants.SENSISION_LABEL_TYPE, dr.getType());
+                  Sensision.update(SensisionConstants.CLASS_WARP_DATALOG_REQUESTS_LOGGED, labels, 1);
+
                   loggingWriter.close();
                   loggingFile.renameTo(new File(loggingFile.getAbsolutePath() + DatalogForwarder.DATALOG_SUFFIX));
                   loggingFile = null;
@@ -239,7 +245,7 @@ public class StandaloneStreamUpdateHandler extends WebSocketHandler.Simple {
                 sb.append(Long.toString(1000000L + (nanos % 1000000L)).substring(1));
                 sb.append("Z");
                 
-                DatalogRequest dr = new DatalogRequest();
+                dr = new DatalogRequest();
                 dr.setTimestamp(nanos);
                 dr.setType(Constants.DATALOG_UPDATE);
                 dr.setId(handler.datalogId);
@@ -360,7 +366,12 @@ public class StandaloneStreamUpdateHandler extends WebSocketHandler.Simple {
               count += lastencoder.getCount();
             }
           } finally {
-            if (null != loggingWriter) {
+            if (null != loggingWriter) {              
+              Map<String,String> labels = new HashMap<String,String>();
+              labels.put(SensisionConstants.SENSISION_LABEL_ID, new String(OrderPreservingBase64.decode(dr.getId().getBytes(Charsets.US_ASCII)), Charsets.UTF_8));
+              labels.put(SensisionConstants.SENSISION_LABEL_TYPE, dr.getType());
+              Sensision.update(SensisionConstants.CLASS_WARP_DATALOG_REQUESTS_LOGGED, labels, 1);
+
               loggingWriter.close();
               loggingFile.renameTo(new File(loggingFile.getAbsolutePath() + DatalogForwarder.DATALOG_SUFFIX));
               loggingFile = null;

--- a/warp10/src/main/java/io/warp10/standalone/StandaloneStreamUpdateHandler.java
+++ b/warp10/src/main/java/io/warp10/standalone/StandaloneStreamUpdateHandler.java
@@ -67,6 +67,8 @@ import org.eclipse.jetty.websocket.api.annotations.WebSocket;
 import org.eclipse.jetty.websocket.server.WebSocketHandler;
 import org.eclipse.jetty.websocket.servlet.WebSocketCreator;
 import org.eclipse.jetty.websocket.servlet.WebSocketServletFactory;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -91,6 +93,8 @@ public class StandaloneStreamUpdateHandler extends WebSocketHandler.Simple {
   private final byte[] datalogPSK;
   private final File loggingDir;
   
+  private final DateTimeFormatter dtf = DateTimeFormat.forPattern("yyyyMMdd'T'HHmmss.SSS").withZoneUTC();
+
   @WebSocket(maxMessageSize=1024 * 1024)
   public static class StandaloneStreamUpdateWebSocket {
     
@@ -229,6 +233,11 @@ public class StandaloneStreamUpdateHandler extends WebSocketHandler.Simple {
                 sb.insert(0, "0000000000000000", 0, 16 - sb.length());
                 sb.append("-");
                 sb.append(handler.datalogId);
+                
+                sb.append("-");
+                sb.append(handler.dtf.print(nanos / 1000000L));
+                sb.append(Long.toString(1000000L + (nanos % 1000000L)).substring(1));
+                sb.append("Z");
                 
                 DatalogRequest dr = new DatalogRequest();
                 dr.setTimestamp(nanos);

--- a/warp10/src/main/java/io/warp10/standalone/StandaloneStreamUpdateHandler.java
+++ b/warp10/src/main/java/io/warp10/standalone/StandaloneStreamUpdateHandler.java
@@ -22,18 +22,24 @@ import io.warp10.continuum.TimeSource;
 import io.warp10.continuum.Tokens;
 import io.warp10.continuum.gts.GTSEncoder;
 import io.warp10.continuum.gts.GTSHelper;
+import io.warp10.continuum.ingress.DatalogForwarder;
 import io.warp10.continuum.ingress.Ingress;
 import io.warp10.continuum.sensision.SensisionConstants;
 import io.warp10.continuum.store.Constants;
 import io.warp10.continuum.store.DirectoryClient;
 import io.warp10.continuum.store.StoreClient;
+import io.warp10.continuum.store.thrift.data.DatalogRequest;
 import io.warp10.continuum.store.thrift.data.Metadata;
+import io.warp10.crypto.CryptoUtils;
 import io.warp10.crypto.KeyStore;
+import io.warp10.crypto.OrderPreservingBase64;
 import io.warp10.quasar.token.thrift.data.WriteToken;
 import io.warp10.sensision.Sensision;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.IOException;
+import java.io.PrintWriter;
 import java.io.StringReader;
 import java.math.BigInteger;
 import java.text.ParseException;
@@ -46,6 +52,10 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.commons.io.output.FileWriterWithEncoding;
+import org.apache.thrift.TException;
+import org.apache.thrift.TSerializer;
+import org.apache.thrift.protocol.TCompactProtocol;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.api.UpgradeRequest;
@@ -57,6 +67,10 @@ import org.eclipse.jetty.websocket.api.annotations.WebSocket;
 import org.eclipse.jetty.websocket.server.WebSocketHandler;
 import org.eclipse.jetty.websocket.servlet.WebSocketCreator;
 import org.eclipse.jetty.websocket.servlet.WebSocketServletFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Charsets;
 
 /**
  * WebSocket handler which handles streaming updates
@@ -66,10 +80,16 @@ import org.eclipse.jetty.websocket.servlet.WebSocketServletFactory;
  */
 public class StandaloneStreamUpdateHandler extends WebSocketHandler.Simple {
     
+  private static final Logger LOG = LoggerFactory.getLogger(StandaloneStreamUpdateHandler.class);
+  
   private final KeyStore keyStore;
   private final Properties properties;
   private final StoreClient storeClient;
   private final StandaloneDirectoryClient directoryClient;
+  
+  private final String datalogId;
+  private final byte[] datalogPSK;
+  private final File loggingDir;
   
   @WebSocket(maxMessageSize=1024 * 1024)
   public static class StandaloneStreamUpdateWebSocket {
@@ -84,6 +104,8 @@ public class StandaloneStreamUpdateHandler extends WebSocketHandler.Simple {
     
     private WriteToken wtoken;
 
+    private String encodedToken;
+    
     /**
      * Cache used to determine if we should push metadata into Kafka or if it was previously seen.
      * Key is a BigInteger constructed from a byte array of classId+labelsId (we cannot use byte[] as map key)
@@ -154,6 +176,9 @@ public class StandaloneStreamUpdateHandler extends WebSocketHandler.Simple {
           
           long now = TimeSource.getTime();
           
+          File loggingFile = null;   
+          PrintWriter loggingWriter = null;
+
           try {
             GTSEncoder lastencoder = null;
             GTSEncoder encoder = null;
@@ -174,11 +199,71 @@ public class StandaloneStreamUpdateHandler extends WebSocketHandler.Simple {
               if (line.startsWith("UPDATE ")) {
                 String[] subtokens = line.split("\\s+");
                 setToken(subtokens[1]);
+                
+                //
+                // Close the current datalog file if it exists
+                //
+                
+                if (null != loggingWriter) {
+                  loggingWriter.close();
+                  loggingFile.renameTo(new File(loggingFile.getAbsolutePath() + DatalogForwarder.DATALOG_SUFFIX));
+                  loggingFile = null;
+                  loggingWriter = null;
+                }
+                
                 continue;
               }
 
               if (null == this.wtoken) {
                 throw new IOException("Missing token.");
+              }
+
+              //
+              // Open the logging file if it is not open yet and if datalogging is enabled
+              //
+              
+              if (null != handler.loggingDir && null == loggingFile) {
+                long nanos = TimeSource.getNanoTime();
+                StringBuilder sb = new StringBuilder();
+                sb.append(Long.toHexString(nanos));
+                sb.insert(0, "0000000000000000", 0, 16 - sb.length());
+                sb.append("-");
+                sb.append(new String(OrderPreservingBase64.encode(handler.datalogId.getBytes(Charsets.UTF_8)), Charsets.US_ASCII));
+                
+                DatalogRequest dr = new DatalogRequest();
+                dr.setTimestamp(nanos);
+                dr.setType(Constants.DATALOG_UPDATE);
+                dr.setId(handler.datalogId);
+                dr.setToken(encodedToken); 
+                
+                //
+                // Serialize the request
+                //
+                
+                TSerializer ser = new TSerializer(new TCompactProtocol.Factory());
+                
+                byte[] encoded;
+                
+                try {
+                  encoded = ser.serialize(dr);
+                } catch (TException te) {
+                  throw new IOException(te);
+                }
+                
+                if (null != handler.datalogPSK) {
+                  encoded = CryptoUtils.wrap(handler.datalogPSK, encoded);
+                }
+                
+                encoded = OrderPreservingBase64.encode(encoded);
+                        
+                loggingFile = new File(handler.loggingDir, sb.toString());
+                loggingWriter = new PrintWriter(new FileWriterWithEncoding(loggingFile, Charsets.UTF_8));
+                
+                //
+                // Write request
+                //
+                
+                loggingWriter.println(new String(encoded, Charsets.US_ASCII));
               }
 
               try {
@@ -241,6 +326,9 @@ public class StandaloneStreamUpdateHandler extends WebSocketHandler.Simple {
                 }
               }
               
+              if (null != loggingWriter) {
+                loggingWriter.println(line);
+              }
             } while (true); 
             
             br.close();
@@ -261,8 +349,15 @@ public class StandaloneStreamUpdateHandler extends WebSocketHandler.Simple {
               lastencoder.setLabelsId(GTSHelper.labelsId(this.handler.keyStore.getKey(KeyStore.SIPHASH_LABELS), lastencoder.getLabels()));
               this.handler.storeClient.store(lastencoder);
               count += lastencoder.getCount();
-            }                  
+            }
           } finally {
+            if (null != loggingWriter) {
+              loggingWriter.close();
+              loggingFile.renameTo(new File(loggingFile.getAbsolutePath() + DatalogForwarder.DATALOG_SUFFIX));
+              loggingFile = null;
+              loggingWriter = null;
+            }
+
             this.handler.storeClient.store(null);
             nano = System.nanoTime() - nano;
             Sensision.update(SensisionConstants.SENSISION_CLASS_CONTINUUM_STANDALONE_STREAM_UPDATE_DATAPOINTS_RAW, sensisionLabels, count);          
@@ -342,7 +437,8 @@ public class StandaloneStreamUpdateHandler extends WebSocketHandler.Simple {
         sensisionLabels.put(SensisionConstants.SENSISION_LABEL_APPLICATION, application);
       }
 
-      this.wtoken = wtoken;            
+      this.wtoken = wtoken;
+      this.encodedToken = token;
     }
   }
   
@@ -353,6 +449,37 @@ public class StandaloneStreamUpdateHandler extends WebSocketHandler.Simple {
     this.storeClient = storeClient;
     this.directoryClient = directoryClient;
     this.properties = properties;
+    
+    if (properties.containsKey(Configuration.DATALOG_DIR)) {
+      File dir = new File(properties.getProperty(Configuration.DATALOG_DIR));
+      
+      if (!dir.exists()) {
+        throw new RuntimeException("Data logging target '" + dir + "' does not exist.");
+      } else if (!dir.isDirectory()) {
+        throw new RuntimeException("Data logging target '" + dir + "' is not a directory.");
+      } else {
+        loggingDir = dir;
+        LOG.info("Data logging enabled in directory '" + dir + "'.");
+      }
+      
+      String id = properties.getProperty(Configuration.DATALOG_ID);
+      
+      if (null == id) {
+        throw new RuntimeException("Property '" + Configuration.DATALOG_ID + "' MUST be set to a unique value for this instance.");
+      } else {
+        datalogId = new String(OrderPreservingBase64.encode(id.getBytes(Charsets.UTF_8)), Charsets.US_ASCII);
+      }
+      
+    } else {
+      loggingDir = null;
+      datalogId = null;
+    }
+    
+    if (properties.containsKey(Configuration.DATALOG_PSK)) {
+      this.datalogPSK = this.keyStore.decodeKey(properties.getProperty(Configuration.DATALOG_PSK));
+    } else {
+      this.datalogPSK = null;
+    }
     
     configure(super.getWebSocketFactory());    
   }

--- a/warp10/src/main/java/io/warp10/standalone/StandaloneStreamUpdateHandler.java
+++ b/warp10/src/main/java/io/warp10/standalone/StandaloneStreamUpdateHandler.java
@@ -228,7 +228,7 @@ public class StandaloneStreamUpdateHandler extends WebSocketHandler.Simple {
                 sb.append(Long.toHexString(nanos));
                 sb.insert(0, "0000000000000000", 0, 16 - sb.length());
                 sb.append("-");
-                sb.append(new String(OrderPreservingBase64.encode(handler.datalogId.getBytes(Charsets.UTF_8)), Charsets.US_ASCII));
+                sb.append(handler.datalogId);
                 
                 DatalogRequest dr = new DatalogRequest();
                 dr.setTimestamp(nanos);

--- a/warp10/src/main/java/io/warp10/standalone/Warp.java
+++ b/warp10/src/main/java/io/warp10/standalone/Warp.java
@@ -298,7 +298,7 @@ public class Warp extends WarpDist implements Runnable {
     // Start the Datalog Forwarder
     //
     
-    if (properties.containsKey(Configuration.DATALOG_FORWARDER_DIR)) {
+    if (properties.containsKey(Configuration.DATALOG_FORWARDER_SRCDIR) && properties.containsKey(Configuration.DATALOG_FORWARDER_DSTDIR)) {
       DatalogForwarder forwarder = new DatalogForwarder(keystore, properties);
     }
     

--- a/warp10/src/main/java/io/warp10/standalone/Warp.java
+++ b/warp10/src/main/java/io/warp10/standalone/Warp.java
@@ -26,6 +26,7 @@ import io.warp10.continuum.egress.EgressExecHandler;
 import io.warp10.continuum.egress.EgressFetchHandler;
 import io.warp10.continuum.egress.EgressFindHandler;
 import io.warp10.continuum.egress.EgressMobiusHandler;
+import io.warp10.continuum.ingress.DatalogForwarder;
 import io.warp10.continuum.store.Constants;
 import io.warp10.continuum.store.StoreClient;
 import io.warp10.crypto.CryptoUtils;
@@ -291,6 +292,14 @@ public class Warp extends WarpDist implements Runnable {
         ScriptRunner runner = new ScriptRunner(keystore.clone(), properties);
       }
 
+    }
+    
+    //
+    // Start the Datalog Forwarder
+    //
+    
+    if (properties.containsKey(Configuration.DATALOG_FORWARDER_DIR)) {
+      DatalogForwarder forwarder = new DatalogForwarder(keystore, properties);
     }
     
     //

--- a/warp10/src/main/thrift/io_warp10_continuum_store_thrift_data.thrift
+++ b/warp10/src/main/thrift/io_warp10_continuum_store_thrift_data.thrift
@@ -344,4 +344,8 @@ struct DatalogRequest {
    * Optional now parameter needed to decode relative timestamps
    */
   5: optional string now,
+  /**
+   * Delete query string. We store it in the request so it cannot be modified in the datalog file
+   */
+  6: optional string deleteQueryString,
 }

--- a/warp10/src/main/thrift/io_warp10_continuum_store_thrift_data.thrift
+++ b/warp10/src/main/thrift/io_warp10_continuum_store_thrift_data.thrift
@@ -319,3 +319,29 @@ struct GTSSplit {
    */
   3: list<Metadata> metadatas,
 }
+
+/**
+ * Datalog request
+ */
+struct DatalogRequest {
+  /**
+   * Timestamp at which the datalog request originated, in ns
+   */
+  1: i64 timestamp,
+  /**
+   * Id of the node where the datalog request originated
+   */
+  2: string id,  
+  /**
+   * Type of datalog request, UPDATE, META, DELETE
+   */
+  3: string type,
+  /**
+   * Associated token
+   */
+  4: string token,
+  /**
+   * Optional now parameter needed to decode relative timestamps
+   */
+  5: optional string now,
+}


### PR DESCRIPTION
Adds a datalog feature to forward UPDATE/META/DELETE actions from one platform to another. Very useful to build an in-memory cache in front of a distributed platform for example.