### PR TITLE
Added labels to Worf CLI arguments

### DIFF
--- a/warp10/src/main/java/io/warp10/worf/WorfCLI.java
+++ b/warp10/src/main/java/io/warp10/worf/WorfCLI.java
@@ -17,6 +17,7 @@ package io.warp10.worf;
 
 import com.google.common.base.Strings;
 import io.warp10.Revision;
+import io.warp10.continuum.gts.GTSHelper;
 import org.apache.commons.cli.*;
 import org.codehaus.jettison.json.JSONObject;
 
@@ -73,7 +74,7 @@ public class WorfCLI {
     options.addOptionGroup(groupOwnerUID);
 
     options.addOption(new Option(APPNAME, "app-name", true, "token application name. Used by token option or @warp:writeToken@ template"));
-    options.addOption(new Option(LABELS, "labels", true, "provide labels to be included in the write token"));
+    options.addOption(new Option(LABELS, "labels", true, "enclosed label list for write token (following ingress input format : xbeeId=XBee_40670F0D,moteId=53)"));
     options.addOption(new Option(TTL, "ttl", true, "token time to live (ms). Used by token option or @warp:writeToken@ template"));
 
 
@@ -105,8 +106,8 @@ public class WorfCLI {
       String ownerUID = null;
       String appName = null;
       String lbs = null;
+      Map<String, String> labels = null;
       boolean labelMap = false;
-      Map<String, String> labels = new HashMap<String, String>();
       long ttl = 0L;
 
       PrintWriter out = new PrintWriter(System.out);
@@ -168,18 +169,15 @@ public class WorfCLI {
           appName = cmd.getOptionValue(APPNAME);
         }
 
-        if (cmd.hasOption(LABELS)) try {
-            lbs = cmd.getOptionValue(LABELS);
-            String[] array = lbs.split(" ");
-            if (array.length % 2 != 0) {
-                throw new WorfException("Odd number of values provided as labels ");
-            }
-            for (int i = 0; i <= array.length - 1; i = +2) {
-                labels.put(array[i], array[i + 1]);
-            }
+        if (cmd.hasOption(LABELS)) {
+          lbs = cmd.getOptionValue(LABELS);
+          try {
+            labels = GTSHelper.parseLabels(lbs);
             labelMap = true;
-        } catch (Exception e) {
-            throw new WorfException("Unable to map your labels : " + e);
+          }
+          catch ( Exception e) {
+            throw new WorfException("Not a valid label selector : " + e.getMessage());
+          }
         }
 
 

--- a/warp10/src/main/java/io/warp10/worf/WorfCLI.java
+++ b/warp10/src/main/java/io/warp10/worf/WorfCLI.java
@@ -25,7 +25,8 @@ import java.io.File;
 import java.io.PrintWriter;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.*;
+import java.util.Properties;
+import java.util.UUID;
 
 public class WorfCLI {
   public static boolean verbose = false;
@@ -49,8 +50,6 @@ public class WorfCLI {
   private static String INTERACTIVE = "i";
   private static String OUTPUT = "o";
   private static String QUIET = "q";
-
-
   private static String TOKEN = "t";
   private static String TTL = "ttl";
   private static String KEYSTORE = "ks";
@@ -133,7 +132,6 @@ public class WorfCLI {
       if (cmd.hasOption(QUIET)) {
         quiet = true;
       }
-
 
       if (cmd.hasOption(OUTPUT)) {
         outputFile = cmd.getOptionValue(OUTPUT);
@@ -328,8 +326,7 @@ public class WorfCLI {
         } else {
            writeToken = keyMaster.deliverWriteToken(appName, producerUID, ownerUID,  ttl);
         }
-
-
+        
         // write outputformat
         JSONObject jsonOutput = new JSONObject();
         JSONObject jsonToken = new JSONObject();

--- a/warp10/src/main/java/io/warp10/worf/WorfCLI.java
+++ b/warp10/src/main/java/io/warp10/worf/WorfCLI.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.PrintWriter;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
 
@@ -326,7 +327,7 @@ public class WorfCLI {
         } else {
            writeToken = keyMaster.deliverWriteToken(appName, producerUID, ownerUID,  ttl);
         }
-        
+
         // write outputformat
         JSONObject jsonOutput = new JSONObject();
         JSONObject jsonToken = new JSONObject();


### PR DESCRIPTION
Allow to pass labels as arguments to create WRITE tokens that carry fixed labels inside the token.