### PR TITLE
Split directory metadatas by any label

### DIFF
--- a/warp10/src/main/java/io/warp10/continuum/Configuration.java
+++ b/warp10/src/main/java/io/warp10/continuum/Configuration.java
@@ -23,7 +23,7 @@ public class Configuration {
   public static final String WARP_COMPONENTS = "warp.components";
 
   public static final String WARP_TOKEN_FILE = "warp.token.file";
-  
+
   public static final String WARP_HASH_CLASS = "warp.hash.class";
   public static final String WARP_HASH_LABELS = "warp.hash.labels";
   public static final String CONTINUUM_HASH_INDEX = "warp.hash.index";
@@ -34,21 +34,21 @@ public class Configuration {
   public static final String WARP_AES_METASETS = "warp.aes.metasets";
   public static final String WARP_AES_LOGGING = "warp.aes.logging";
   public static final String WARP_DEFAULT_AES_LOGGING = "hex:3cf5cee9eadddba796f2cce0762f308ad9df36f4883841e167dab2889bcf215b";
-  
+
   public static final String WARP_IDENT = "warp.ident";
-  
+
   public static final String WARP10_QUIET = "warp10.quiet";
-  
+
   /**
    * List of Warp 10 plugins to initialize
    */
   public static final String WARP10_PLUGINS = "warp10.plugins";
-  
+
   /**
    * Maximum number of subscriptions per plasma connection
    */
   public static final String WARP_PLASMA_MAXSUBS = "warp.plasma.maxsubs";
-  
+
   /**
    * Maximum encoder size (in bytes) for internal data transfers. Use values from 64k to 512k for
    * optimum performance and make sure this size is less than the maximum message size of Kafka
@@ -60,19 +60,19 @@ public class Configuration {
    * How often (in ms) should we refetch the region start/end keys
    */
   public static final String WARP_HBASE_REGIONKEYS_UPDATEPERIOD = "warp.hbase.regionkeys.updateperiod";
-  
+
   /**
    * Comma separated list of additional languages to support within WarpScript
    * This MUST be set as a system property
    */
   public static final String CONFIG_WARPSCRIPT_LANGUAGES = "warpscript.languages";
-  
+
   /**
    * Comma separated list of WarpScriptExtension classes to instantiate to modify
    * the defined WarpScript functions.
    */
   public static final String CONFIG_WARPSCRIPT_EXTENSIONS = "warpscript.extensions";
-  
+
   /**
    * This configuration parameter determines if undefining a function (via NULL 'XXX' DEF)
    * will unshadow the original statement thus making it available again or if it will replace
@@ -80,7 +80,7 @@ public class Configuration {
    * The safest behavior is to leave this undefined or set to 'false'.
    */
   public static final String WARPSCRIPT_DEF_UNSHADOW = "warpscript.def.unshadow";
-  
+
   public static final String WARPSCRIPT_MAX_OPS = "warpscript.maxops";
   public static final String WARPSCRIPT_MAX_BUCKETS = "warpscript.maxbuckets";
   public static final String WARPSCRIPT_MAX_DEPTH = "warpscript.maxdepth";
@@ -118,7 +118,7 @@ public class Configuration {
    * List of patterns to include/exclude for hosts in WebCall calls
    *
    * Typical value is .*,!^127.0.0.1$,!^localhost$,!^192.168.*,!^10.*,!^172.(16|17|18|19|20|21|22|23|24|25|26|27|28|29|39|31)\..*
-   * 
+   *
    */
   public static final String WEBCALL_HOST_PATTERNS = "webcall.host.patterns";
 
@@ -126,32 +126,32 @@ public class Configuration {
    * ZK Quorum to use for reaching the Kafka cluster to consume WebCall requests
    */
   public static final String WEBCALL_KAFKA_ZKCONNECT = "webcall.kafka.zkconnect";
-  
+
   /**
    * List of Kafka brokers to use for sending WebCall requests
    */
   public static final String WEBCALL_KAFKA_BROKERLIST = "webcall.kafka.brokerlist";
-  
+
   /**
    * Topic to use for WebCall requests
    */
   public static final String WEBCALL_KAFKA_TOPIC = "webcall.kafka.topic";
-  
+
   /**
    * AES key to use for encrypting WebCall requests
    */
   public static final String WEBCALL_KAFKA_AES = "webcall.kafka.aes";
-  
+
   /**
    * SipHash key to use for computing WebCall requests HMACs
    */
   public static final String WEBCALL_KAFKA_MAC = "webcall.kafka.mac";
-  
+
   /**
    * Kafka client id to use when consuming WebCall requests
    */
   public static final String WEBCALL_KAFKA_CONSUMER_CLIENTID = "webcall.kafka.consumer.clientid";
-  
+
   /**
    * Name of partition assignment strategy to use
    */
@@ -166,12 +166,12 @@ public class Configuration {
    * How many threads to spawn
    */
   public static final String WEBCALL_NTHREADS = "webcall.nthreads";
-  
+
   /**
    * Groupid to use when consuming Kafka
    */
   public static final String WEBCALL_KAFKA_GROUPID = "webcall.kafka.groupid";
-  
+
   /**
    * How often to commit the Kafka offsets
    */
@@ -190,7 +190,7 @@ public class Configuration {
    * Path of the 'bootstrap' Einstein code for Egress
    */
   public static final String CONFIG_WARPSCRIPT_BOOTSTRAP_PATH = "warpscript.bootstrap.path";
-  
+
   /**
    * How often to reload the bootstrap code (in ms) for Egress
    */
@@ -200,12 +200,12 @@ public class Configuration {
    * Path of the 'bootstrap' Einstein code for Mobius
    */
   public static final String CONFIG_WARPSCRIPT_MOBIUS_BOOTSTRAP_PATH = "warpscript.mobius.bootstrap.path";
-  
+
   /**
    * Number of threads in the Mobius pool
    */
   public static final String CONFIG_WARPSCRIPT_MOBIUS_POOL = "warpscript.mobius.pool";
-  
+
   /**
    * How often to reload the bootstrap code (in ms) for Mobius
    */
@@ -215,7 +215,7 @@ public class Configuration {
    * Path of the 'bootstrap' Einstein code for Runner
    */
   public static final String CONFIG_WARPSCRIPT_RUNNER_BOOTSTRAP_PATH = "warpscript.runner.bootstrap.path";
-  
+
   /**
    * How often to reload the bootstrap code (in ms) for Mobius
    */
@@ -225,7 +225,7 @@ public class Configuration {
    * URL for the 'update' endpoint accessed in UPDATE
    */
   public static final String CONFIG_WARPSCRIPT_UPDATE_ENDPOINT = "warpscript.update.endpoint";
-  
+
   /**
    * URL for the 'meta' endpoint accessed in META
    */
@@ -235,7 +235,7 @@ public class Configuration {
    * URL for the 'delete' endpoint accessed in DELETE
    */
   public static final String CONFIG_WARPSCRIPT_DELETE_ENDPOINT = "warpscript.delete.endpoint";
-  
+
   /**
    * Pre-Shared key for signing fetch requests. Signed fetch request expose owner/producer
    */
@@ -251,12 +251,12 @@ public class Configuration {
    * Maximum number of classes for which to report detailed stats in 'stats'
    */
   public static String DIRECTORY_STATS_CLASS_MAXCARDINALITY = "directory.stats.class.maxcardinality";
-  
+
   /**
    * Maximum number of labels for which to report detailed stats in 'stats'
    */
   public static String DIRECTORY_STATS_LABELS_MAXCARDINALITY = "directory.stats.labels.maxcardinality";
-  
+
   /**
    * Maximum size of Thrift frame for directory service
    */
@@ -271,29 +271,29 @@ public class Configuration {
    * Hard limit on number of find results. After this limit, the find request will fail.
    */
   public static String DIRECTORY_FIND_MAXRESULTS_HARD = "directory.find.maxresults.hard";
-  
+
   /**
    * Zookeeper ZK connect string for Kafka ('metadata' topic)
-   */  
+   */
   public static final String DIRECTORY_KAFKA_METADATA_ZKCONNECT = "directory.kafka.metadata.zkconnect";
-  
+
   /**
    * Actual 'metadata' topic
    */
   public static final String DIRECTORY_KAFKA_METADATA_TOPIC = "directory.kafka.metadata.topic";
-  
+
   /**
    * Key to use for computing MACs (128 bits in hex or OSS reference)
    */
   public static final String DIRECTORY_KAFKA_METADATA_MAC = "directory.kafka.metadata.mac";
-  
+
   /**
-   * Key to use for encrypting payloads (128/192/256 bits in hex or OSS reference) 
+   * Key to use for encrypting payloads (128/192/256 bits in hex or OSS reference)
    */
   public static final String DIRECTORY_KAFKA_METADATA_AES = "directory.kafka.metadata.aes";
 
   /**
-   * Key to use for encrypting metadata in HBase (128/192/256 bits in hex or OSS reference) 
+   * Key to use for encrypting metadata in HBase (128/192/256 bits in hex or OSS reference)
    */
   public static final String DIRECTORY_HBASE_METADATA_AES = "directory.hbase.metadata.aes";
 
@@ -311,12 +311,12 @@ public class Configuration {
    * Name of partition assignment strategy to use
    */
   public static final String DIRECTORY_KAFKA_METADATA_CONSUMER_PARTITION_ASSIGNMENT_STRATEGY = "directory.kafka.metadata.consumer.partition.assignment.strategy";
-  
+
   /**
    * Strategy to adopt if consuming for the first time or if the last committed offset is past Kafka history
    */
   public static final String DIRECTORY_KAFKA_METADATA_CONSUMER_AUTO_OFFSET_RESET = "directory.kafka.metadata.consumer.auto.offset.reset";
-  
+
   /**
    * Delay between synchronization for offset commit
    */
@@ -326,7 +326,7 @@ public class Configuration {
    * Maximum byte size we allow the pending Puts list to grow to
    */
   public static final String DIRECTORY_HBASE_METADATA_MAXPENDINGPUTSSIZE = "directory.hbase.metadata.pendingputs.size";
-  
+
   /**
    * ZooKeeper Quorum for locating HBase
    */
@@ -341,12 +341,12 @@ public class Configuration {
    * HBase table where metadata should be stored
    */
   public static final String DIRECTORY_HBASE_METADATA_TABLE = "directory.hbase.metadata.table";
-  
+
   /**
    * Columns family under which metadata should be stored
    */
   public static final String DIRECTORY_HBASE_METADATA_COLFAM = "directory.hbase.metadata.colfam";
-  
+
   /**
    * Parent znode under which HBase znodes will be created
    */
@@ -356,12 +356,12 @@ public class Configuration {
    * ZooKeeper server list for registering
    */
   public static final String DIRECTORY_ZK_QUORUM = "directory.zk.quorum";
-  
+
   /**
    * ZooKeeper znode under which to register
    */
   public static final String DIRECTORY_ZK_ZNODE = "directory.zk.znode";
-  
+
   /**
    * Number of threads to run for ingesting metadata from Kafka
    */
@@ -376,12 +376,12 @@ public class Configuration {
    * Partition of metadatas we focus on, format is MODULUS:REMAINDER
    */
   public static final String DIRECTORY_PARTITION = "directory.partition";
-  
+
   /**
    * Port on which the DirectoryService will listen
    */
   public static final String DIRECTORY_PORT = "directory.port";
-  
+
   /**
    * Port the streaming directory service listens to
    */
@@ -406,12 +406,12 @@ public class Configuration {
    * Idle timeout for the streaming directory endpoint
    */
   public static final String DIRECTORY_STREAMING_IDLE_TIMEOUT = "directory.streaming.idle.timeout";
-  
+
   /**
    * Number of threads in Jetty's Thread Pool
    */
   public static final String DIRECTORY_STREAMING_THREADPOOL = "directory.streaming.threadpool";
-  
+
   /**
    * Maximum size of Jetty ThreadPool queue size (unbounded by default)
    */
@@ -421,12 +421,12 @@ public class Configuration {
    * Address on which the DirectoryService will listen
    */
   public static final String DIRECTORY_HOST = "directory.host";
-  
+
   /**
    * Pre-Shared Key for request fingerprinting
    */
   public static final String DIRECTORY_PSK = "directory.psk";
-  
+
   /**
    * Max age of Find requests
    */
@@ -436,7 +436,7 @@ public class Configuration {
    * Number of threads to use for the initial loading of Metadata
    */
   public static final String DIRECTORY_INIT_NTHREADS = "directory.init.nthreads";
-  
+
   /**
    * Boolean indicating whether or not we should initialized Directory by reading HBase
    */
@@ -456,60 +456,65 @@ public class Configuration {
    * Boolean indicting whether or not we should register in ZK
    */
   public static final String DIRECTORY_REGISTER = "directory.register";
-  
+
   /**
    * Class name of directory plugin to use
    */
   public static final String DIRECTORY_PLUGIN_CLASS = "directory.plugin.class";
-  
+
   /**
    * Boolean indicating whether or not we should use the HBase filter when initializing
    */
   public static final String DIRECTORY_HBASE_FILTER = "directory.hbase.filter";
-  
+
   /**
    * Size of metadata cache in number of entries
    */
   public static final String DIRECTORY_METADATA_CACHE_SIZE = "directory.metadata.cache.size";
 
+  /**
+   * Split directory index on the given label
+   */
+  public static final String DIRECTORY_SPLIT_LABEL = "directory.split.label";
+
   //
   // I N G R E S S
   //
   /////////////////////////////////////////////////////////////////////////////////////////
-  
+
   /**
    * Should we shuffle the GTS prior to issueing delete messages. Set to true or false.
    * It is highly recommended to set this to true as it will induce a much lower pressure
    * on region servers.
    */
   public static final String INGRESS_DELETE_SHUFFLE = "ingress.delete.shuffle";
-  
+
   /**
    * If set to 'true' the /delete endpoint will reject all requests. This is useful
    * to have ingress endpoints which only honor meta and update.
    */
   public static final String INGRESS_DELETE_REJECT = "ingress.delete.reject";
-  
+
   /**
    * Path where the metadata cache should be dumped
    */
   public static final String INGRESS_CACHE_DUMP_PATH = "ingress.cache.dump.path";
-  
+
   /**
    * Maximum value size, make sure it is less than 'max.encoder.size'
    */
   public static final String INGRESS_VALUE_MAXSIZE = "ingress.value.maxsize";
-  
+
   /**
    * Identification of Ingress as the Metadata source
    */
   public static final String INGRESS_METADATA_SOURCE = "ingress";
-  
+
   /**
    * Identification of Ingress/Delete as the Metadata source
    */
   public static final String INGRESS_METADATA_DELETE_SOURCE = "delete";
-  
+
   /**
    * Identification of Ingress Metadata Update endpoint source
    */
@@ -524,57 +529,57 @@ public class Configuration {
    * Host onto which the ingress server should listen
    */
   public static final String INGRESS_HOST = "ingress.host";
-  
+
   /**
    * Port onto which the ingress server should listen
    */
   public static final String INGRESS_PORT = "ingress.port";
-  
+
   /**
    * Size of metadata cache in number of entries
    */
   public static final String INGRESS_METADATA_CACHE_SIZE = "ingress.metadata.cache.size";
-  
+
   /**
    * Number of acceptors
    */
   public static final String INGRESS_ACCEPTORS = "ingress.acceptors";
-  
+
   /**
    * Number of selectors
    */
   public static final String INGRESS_SELECTORS = "ingress.selectors";
-  
+
   /**
    * Idle timeout
    */
   public static final String INGRESS_IDLE_TIMEOUT = "ingress.idle.timeout";
-  
+
   /**
    * Number of threads in Jetty's Thread Pool
    */
   public static final String INGRESS_JETTY_THREADPOOL = "ingress.jetty.threadpool";
-  
+
   /**
    * Maximum size of Jetty ThreadPool queue size (unbounded by default)
    */
   public static final String INGRESS_JETTY_MAXQUEUESIZE = "ingress.jetty.maxqueuesize";
-    
+
   /**
    * Max message size for the stream update websockets
    */
   public static final String INGRESS_WEBSOCKET_MAXMESSAGESIZE = "ingress.websocket.maxmessagesize";
-  
+
   /**
    * ZooKeeper server list
    */
   public static final String INGRESS_ZK_QUORUM = "ingress.zk.quorum";
-  
+
   /**
    * ZK Connect String for the metadata kafka cluster
    */
   public static final String INGRESS_KAFKA_META_ZKCONNECT = "ingress.kafka.metadata.zkconnect";
-  
+
   /**
    * Kafka broker list for the 'meta' topic
    */
@@ -588,7 +593,7 @@ public class Configuration {
   /**
    * Actual 'meta' topic
    */
-  public static final String INGRESS_KAFKA_META_TOPIC = "ingress.kafka.metadata.topic";    
+  public static final String INGRESS_KAFKA_META_TOPIC = "ingress.kafka.metadata.topic";
 
   /**
    * Offset reset strategy.
@@ -599,17 +604,17 @@ public class Configuration {
    * Key to use for computing MACs (128 bits in hex or OSS reference)
    */
   public static final String INGRESS_KAFKA_META_MAC = "ingress.kafka.metadata.mac";
-  
+
   /**
    * Key to use for encrypting payloads (128/192/256 bits in hex or OSS reference)
    */
   public static final String INGRESS_KAFKA_META_AES = "ingress.kafka.metadata.aes";
-  
+
   /**
    * Groupid to use for consuming the 'metadata' topic
    */
   public static final String INGRESS_KAFKA_META_GROUPID = "ingress.kafka.metadata.groupid";
-  
+
   /**
    * Client id to use for consuming the 'metadata' topic
    */
@@ -644,7 +649,7 @@ public class Configuration {
    * Actual 'data' topic
    */
   public static final String INGRESS_KAFKA_DATA_TOPIC = "ingress.kafka.data.topic";
-  
+
   /**
    * Size of Kafka Producer pool for the 'data' topic
    */
@@ -654,7 +659,7 @@ public class Configuration {
    * Request timeout when talking to Kafka
    */
   public static final String INGRESS_KAFKA_DATA_REQUEST_TIMEOUT_MS = "ingress.kafka.data.request.timeout.ms";
-  
+
   /**
    * Size of Kafka Producer pool for the 'metadata' topic
    */
@@ -664,17 +669,17 @@ public class Configuration {
    * Key to use for computing MACs (128 bits in hex or OSS reference)
    */
   public static final String INGRESS_KAFKA_DATA_MAC = "ingress.kafka.data.mac";
-  
+
   /**
-   * Key to use for encrypting payloads (128/192/256 bits in hex or OSS reference) 
+   * Key to use for encrypting payloads (128/192/256 bits in hex or OSS reference)
    */
   public static final String INGRESS_KAFKA_DATA_AES = "ingress.kafka.data.aes";
-  
+
   /**
    * Maximum message size for the 'data' topic
    */
   public static final String INGRESS_KAFKA_DATA_MAXSIZE = "ingress.kafka.data.maxsize";
-  
+
   /**
    * Maximum message size for the 'metadata' topic
    */
@@ -684,54 +689,54 @@ public class Configuration {
    * Kafka broker list for the throttling topic
    */
   public static final String INGRESS_KAFKA_THROTTLING_BROKERLIST = "ingress.kafka.throttling.brokerlist";
-  
+
   /**
    * Optional client id to use when producing messages in the throttling topic
    */
   public static final String INGRESS_KAFKA_THROTTLING_PRODUCER_CLIENTID = "ingress.kafka.throttling.producer.clientid";
-  
+
   /**
    * Kafka producer timeout for the throttling topic
    */
   public static final String INGRESS_KAFKA_THROTTLING_REQUEST_TIMEOUT_MS = "ingress.kafka.throttling.request.timeout.ms";
-  
+
   /**
    * Name of the throttling topic
    */
   public static final String INGRESS_KAFKA_THROTTLING_TOPIC = "ingress.kafka.throttling.topic";
-  
+
   /**
    * ZK connect string for the throttling kafka cluster
    */
   public static final String INGRESS_KAFKA_THROTTLING_ZKCONNECT = "ingress.kafka.throttling.zkconnect";
-  
+
   /**
    * Client id to use when consuming the throttling topic
    */
   public static final String INGRESS_KAFKA_THROTTLING_CONSUMER_CLIENTID = "ingress.kafka.throttling.consumer.clientid";
-  
+
   /**
    * Group id to use when consuming the throttling topic
    */
   public static final String INGRESS_KAFKA_THROTTLING_GROUPID = "ingress.kafka.throttling.groupid";
-  
+
   /**
    * Auto offset strategy to use when consuming the throttling topic. Set to 'largest' unless you want to do
    * a special experiment.
    */
   public static final String INGRESS_KAFKA_THROTTLING_CONSUMER_AUTO_OFFSET_RESET = "ingress.kafka.throttling.consumer.auto.offset.reset";
-  
+
   //
   // S T O R E
   //
   /////////////////////////////////////////////////////////////////////////////////////////
-  
+
   /**
    * Comma separated list of Store related HBase configuration keys to extract from the Warp 10 configuration.
    * The listed keys will be extracted from 'store.' prefixed configuration keys.
    */
   public static final String STORE_HBASE_CONFIG = "store.hbase.config";
-  
+
   /**
    * Path to the throttling file. This file contains a single line with a double value in [0.0,1.0]
    */
@@ -746,17 +751,17 @@ public class Configuration {
    * How much to wait when the consumption was throttled, in ns (nanoseconds), defaults to 10 ms (milliseconds)
    */
   public static final String STORE_THROTTLING_DELAY = "store.throttling.delay";
-  
+
   /**
    * Key for encrypting data in HBase
    */
   public static final String STORE_HBASE_DATA_AES = "store.hbase.data.aes";
-  
+
   /**
    * Zookeeper ZK connect string for Kafka ('data' topic)
-   */  
+   */
   public static final String STORE_KAFKA_DATA_ZKCONNECT = "store.kafka.data.zkconnect";
-  
+
   /**
    * Kafka broker list for the 'data' topic
    */
@@ -771,14 +776,14 @@ public class Configuration {
    * Actual 'data' topic
    */
   public static final String STORE_KAFKA_DATA_TOPIC = "store.kafka.data.topic";
-  
+
   /**
    * Key to use for computing MACs (128 bits in hex or OSS reference)
    */
   public static final String STORE_KAFKA_DATA_MAC = "store.kafka.data.mac";
-  
+
   /**
-   * Key to use for encrypting payloads (128/192/256 bits in hex or OSS reference) 
+   * Key to use for encrypting payloads (128/192/256 bits in hex or OSS reference)
    */
   public static final String STORE_KAFKA_DATA_AES = "store.kafka.data.aes";
 
@@ -791,7 +796,7 @@ public class Configuration {
    * Client id to use to consume the data topic
    */
   public static final String STORE_KAFKA_DATA_CONSUMER_CLIENTID = "store.kafka.data.consumer.clientid";
-  
+
   /**
    * Name of partition assignment strategy to use
    */
@@ -806,28 +811,28 @@ public class Configuration {
    * Maximum time between offset synchronization
    */
   public static final String STORE_KAFKA_DATA_INTERCOMMITS_MAXTIME = "store.kafka.data.intercommits.maxtime";
-  
+
   /**
    * Maximum size we allow the Puts list to grow to
    */
   public static final String STORE_HBASE_DATA_MAXPENDINGPUTSSIZE = "store.hbase.data.maxpendingputssize";
-  
+
   /**
    * How many threads to spawn for consuming
    */
   public static final String STORE_NTHREADS = "store.nthreads";
-  
+
   /**
    * Number of threads for consuming Kafka in each one of the 'store.nthreads' hbase threads. Defaults to 1
    */
   public static final String STORE_NTHREADS_KAFKA = "store.nthreads.kafka";
-  
+
   /**
    * Number of threads in the pool used to process deletes. One such pool is created for each of 'store.nthreads'. Defaults to
    * 0 meaning no pool is used.
    */
   public static final String STORE_NTHREADS_DELETE = "store.nthreads.delete";
-  
+
   /**
    * ZooKeeper connect string for HBase
    */
@@ -837,17 +842,17 @@ public class Configuration {
    * ZooKeeper port for HBase client
    */
   public static final String STORE_HBASE_ZOOKEEPER_PROPERTY_CLIENTPORT = "store.hbase.zookeeper.property.clientPort";
-  
+
   /**
    * HBase table where data should be stored
    */
   public static final String STORE_HBASE_DATA_TABLE = "store.hbase.data.table";
-  
+
   /**
    * Columns family under which data should be stored
    */
   public static final String STORE_HBASE_DATA_COLFAM = "store.hbase.data.colfam";
-  
+
   /**
    * Parent znode under which HBase znodes will be created
    */
@@ -857,12 +862,12 @@ public class Configuration {
    * Custom value of 'hbase.hconnection.threads.max' for the Store HBase pool
    */
   public static final String STORE_HBASE_HCONNECTION_THREADS_MAX = "store.hbase.hconnection.threads.max";
-  
+
   /**
    * Custom value of 'hbase.client.ipc.pool.size' for the Store HBase pool
    */
   public static final String STORE_HBASE_CLIENT_IPC_POOL_SIZE = "store.hbase.client.ipc.pool.size";
-  
+
   /**
    * Custom value of 'hbase.hconnection.threads.core' for the Store HBase pool (MUST be <= STORE_HBASE_HCONNECTION_THREADS_MAX)
    */
@@ -879,12 +884,12 @@ public class Configuration {
    * Timeout (in ms) for client operations (bulk delete, region listing, ..) in the Store HBase client. Defaults to 1200000 ms.
    */
   public static final String STORE_HBASE_CLIENT_OPERATION_TIMEOUT = "store.hbase.client.operation.timeout";
-  
+
   /**
    * Number of times to retry RPCs in the Store HBase client. HBase default is 31.
    */
   public static final String STORE_HBASE_CLIENT_RETRIES_NUMBER = "store.hbase.client.retries.number";
-  
+
   /**
    * Pause (in ms) between retries for the Store HBase client. HBase default is 100ms
    */
@@ -894,17 +899,17 @@ public class Configuration {
   // P L A S M A
   //
   /////////////////////////////////////////////////////////////////////////////////////////
-  
+
   /**
    * ZooKeeper connect string for Kafka consumer
    */
   public static final String PLASMA_FRONTEND_KAFKA_ZKCONNECT = "plasma.frontend.kafka.zkconnect";
-  
+
   /**
    * Kafka topic to consume. This topic is dedicated to this Plasma frontend.
    */
   public static final String PLASMA_FRONTEND_KAFKA_TOPIC = "plasma.frontend.kafka.topic";
-  
+
   /**
    * Kafka groupid under which to consume above topic
    */
@@ -924,42 +929,42 @@ public class Configuration {
    * How often (in ms) to commit Kafka offsets
    */
   public static final String PLASMA_FRONTEND_KAFKA_COMMITPERIOD = "plasma.frontend.kafka.commitperiod";
-  
+
   /**
    * Number of threads used for consuming Kafka topic
    */
   public static final String PLASMA_FRONTEND_KAFKA_NTHREADS = "plasma.frontend.kafka.nthreads";
-  
+
   /**
    * Optional AES key for messages in Kafka
    */
   public static final String PLASMA_FRONTEND_KAFKA_AES = "plasma.frontend.kafka.aes";
-  
+
   /**
    * ZooKeeper connect String for subscription
    */
   public static final String PLASMA_FRONTEND_ZKCONNECT = "plasma.frontend.zkconnect";
-  
+
   /**
    * ZooKeeper root znode for subscrptions
    */
   public static final String PLASMA_FRONTEND_ZNODE = "plasma.frontend.znode";
-  
+
   /**
    * Maximum size of each znode (in bytes)
    */
   public static final String PLASMA_FRONTEND_MAXZNODESIZE = "plasma.frontend.maxznodesize";
-  
+
   /**
    * Host/IP on which to bind
    */
   public static final String PLASMA_FRONTEND_HOST = "plasma.frontend.host";
-  
+
   /**
    * Port on which to listen
    */
   public static final String PLASMA_FRONTEND_PORT = "plasma.frontend.port";
-  
+
   /**
    * Number of acceptors
    */
@@ -974,36 +979,36 @@ public class Configuration {
    * Max message size for the Plasma Frontend Websocket
    */
   public static final String PLASMA_FRONTEND_WEBSOCKET_MAXMESSAGESIZE = "plasma.frontend.websocket.maxmessagesize";
-  
+
   /**
    * Idle timeout
    */
   public static final String PLASMA_FRONTEND_IDLE_TIMEOUT = "plasma.frontend.idle.timout";
-  
+
   /**
    * SipHash key for computing MACs of Kafka messages
    */
   public static final String PLASMA_FRONTEND_KAFKA_MAC = "plasma.frontend.kafka.mac";
-  
+
   public static final String PLASMA_FRONTEND_SUBSCRIBE_DELAY = "plasma.frontend.subscribe.delay";
-  
+
   /**
    * Zookeeper ZK connect string for Kafka ('in' topic)
-   */  
+   */
   public static final String PLASMA_BACKEND_KAFKA_IN_ZKCONNECT = "plasma.backend.kafka.in.zkconnect";
-  
+
   /**
    * Actual 'in' topic
    */
   public static final String PLASMA_BACKEND_KAFKA_IN_TOPIC = "plasma.backend.kafka.in.topic";
-  
+
   /**
    * Key to use for computing MACs (128 bits in hex or OSS reference)
    */
   public static final String PLASMA_BACKEND_KAFKA_IN_MAC = "plasma.backend.kafka.in.mac";
-  
+
   /**
-   * Key to use for encrypting payloads (128/192/256 bits in hex or OSS reference) 
+   * Key to use for encrypting payloads (128/192/256 bits in hex or OSS reference)
    */
   public static final String PLASMA_BACKEND_KAFKA_IN_AES = "plasma.backend.kafka.in.aes";
 
@@ -1051,9 +1056,9 @@ public class Configuration {
    * Key to use for computing MACs (128 bits in hex or OSS reference)
    */
   public static final String PLASMA_BACKEND_KAFKA_OUT_MAC = "plasma.backend.kafka.out.mac";
-  
+
   /**
-   * Key to use for encrypting payloads (128/192/256 bits in hex or OSS reference) 
+   * Key to use for encrypting payloads (128/192/256 bits in hex or OSS reference)
    */
   public static final String PLASMA_BACKEND_KAFKA_OUT_AES = "plasma.backend.kafka.out.aes";
 
@@ -1061,71 +1066,71 @@ public class Configuration {
    * ZooKeeper Quorum for the ZK ensemble to use for retrieving subscriptions
    */
   public static final String PLASMA_BACKEND_SUBSCRIPTIONS_ZKCONNECT = "plasma.backend.subscriptions.zkconnect";
-  
+
   /**
    * Parent znode under which subscription znodes will be created
    */
   public static final String PLASMA_BACKEND_SUBSCRIPTIONS_ZNODE = "plasma.backend.subscriptions.znode";
-    
+
 
   //
   // R U N N E R
   //
   /////////////////////////////////////////////////////////////////////////////////////////
-  
+
   /**
    * ZooKeeper connect string for the leader election among schedulers
    */
   public static final String RUNNER_ZK_QUORUM = "runner.zk.quorum";
-  
+
   /**
    * Znode to use for the leader election among schedulers
    */
   public static final String RUNNER_ZK_ZNODE = "runner.zk.znode";
-  
+
   /**
    * String uniquely identifying this instance of ScriptRunner
    */
   public static final String RUNNER_ID = "runner.id";
-  
+
   /**
    * Roles of the ScriptRunner instance. Can either be 'standalone' or any combination of 'scheduler' and 'worker'.
    */
   public static final String RUNNER_ROLES = "runner.roles";
-  
+
   /**
    * Root directory under which scripts to run reside. The scripts MUST have a '.mc2' extension
    * and reside in subdirectories of this root directory whose name is the periodicity (in ms) at
    * which to run them.
    */
   public static final String RUNNER_ROOT = "runner.root";
-  
+
   /**
    * Number of threads to use for running scripts.
    */
   public static final String RUNNER_NTHREADS = "runner.nthreads";
-  
+
   /**
    * How often (in ms) to scan RUNNER_ROOT for new scripts
    */
   public static final String RUNNER_SCANPERIOD = "runner.scanperiod";
-  
+
   /**
    * Einstein endpoint to use for executing the scripts
    */
   public static final String RUNNER_ENDPOINT = "runner.endpoint";
-  
+
   /**
    * Minimum period at which a script can be scheduled. Any script scheduled
    * more often than that won't be run
    */
   public static final String RUNNER_MINPERIOD = "runner.minperiod";
-  
+
   /**
    * ZooKeeper connect string for the Kafka cluster
    */
   public static final String RUNNER_KAFKA_ZKCONNECT = "runner.kafka.zkconnect";
-  
+
   /**
    * List of Kafka brokers
    */
@@ -1140,12 +1145,12 @@ public class Configuration {
    * Size of Kafka producer pool
    */
   public static final String RUNNER_KAFKA_POOLSIZE = "runner.kafka.poolsize";
-  
+
   /**
    * Topic to use to submit the scripts
    */
   public static final String RUNNER_KAFKA_TOPIC = "runner.kafka.topic";
-  
+
   /**
    * Groupid to use when consuming scripts
    */
@@ -1165,17 +1170,17 @@ public class Configuration {
    * Number of threads to spawn to consume scripts
    */
   public static final String RUNNER_KAFKA_NTHREADS = "runner.kafka.nthreads";
-  
+
   /**
    * Commit period for the script topic
    */
   public static final String RUNNER_KAFKA_COMMITPERIOD = "runner.kafka.commitperiod";
-  
+
   /**
    * Key for integrity checks
    */
   public static final String RUNNER_KAFKA_MAC = "runner.kafka.mac";
-  
+
   /**
    * Key for encryption of scripts on topic
    */
@@ -1185,48 +1190,48 @@ public class Configuration {
    * PreShared key for identifying scripts executing from runner
    */
   public static final String RUNNER_PSK = "runner.psk";
-  
+
   //
   // S T A N D A L O N E
   //
   /////////////////////////////////////////////////////////////////////////////////////////
-  
+
   /**
    * Directory where the leveldb files should be created
    */
   public static final String LEVELDB_HOME = "leveldb.home";
-  
+
   /**
    * Maximum number of open files to use for LevelDB
    */
   public static final String LEVELDB_MAXOPENFILES = "leveldb.maxopenfiles";
-  
+
   /**
    * AES key to use for wrapping metadata prior to storage in leveldb
    */
   public static final String LEVELDB_METADATA_AES = "leveldb.metadata.aes";
-  
+
   /**
    * AES key to use for wrapping datapoints prior to storage in leveldb
    */
   public static final String LEVELDB_DATA_AES = "leveldb.data.aes";
-  
+
   /**
    * @deprecated
    * AES key to use for storing index details in leveldb
    */
   public static final String LEVELDB_INDEX_AES = "leveldb.index.aes";
-  
+
   /**
    * Cache size for leveldb (in bytes)
    */
   public static final String LEVELDB_CACHE_SIZE = "leveldb.cache.size";
-  
+
   /**
    * Compression type to use for leveldb (SNAPPY/NONE)
    */
   public static final String LEVELDB_COMPRESSION_TYPE = "leveldb.compression.type";
-  
+
   /**
    * IP to bind to for listening to incoming connections. Use 0.0.0.0 to listen to all interfaces
    */
@@ -1246,7 +1251,7 @@ public class Configuration {
    * Idle timeout
    */
   public static final String STANDALONE_IDLE_TIMEOUT = "standalone.idle.timeout";
-  
+
   /**
    * Number of Jetty selectors
    */
@@ -1256,64 +1261,64 @@ public class Configuration {
    * Maximum encoder size (in bytes) for internal data transfers. Use values from 64k to 512k
    */
   public static final String STANDALONE_MAX_ENCODER_SIZE = "standalone.max.encoder.size";
-  
+
   /**
    * Maximum size in bytes of a value
    */
   public static final String STANDALONE_VALUE_MAXSIZE = "standalone.value.maxsize";
-  
+
   /**
    * Path to a file to use for triggering compaction suspension to take snapshots
    */
   public static final String STANDALONE_SNAPSHOT_TRIGGER = "standalone.snapshot.trigger";
-  
+
   /**
    * Path to a file to use for signaling that compactions are suspended
    */
   public static final String STANDALONE_SNAPSHOT_SIGNAL = "standalone.snapshot.signal";
-  
+
   /**
    * Directory where data requests should be logged. This directory should be in 700 to protect sensitive token infos.
    */
   public static final String DATALOG_DIR = "datalog.dir";
-  
+
   /**
    * Id of this datalog node. The id will be used in the file name and will be passed down to child nodes via
    * a header.
    */
   public static final String DATALOG_ID = "datalog.id";
-  
+
   /**
    * Pre-shared AES key to wrap datalog.id and datalog.timestamp header values
    */
   public static final String DATALOG_PSK = "datalog.psk";
-  
+
   /**
    * Flag indicating whether or not to log forwarded requests.
    */
   public static final String DATALOG_LOGFORWARDED = "datalog.logforwarded";
-  
+
   /**
    * Configuration key to modify the datalog header
    */
   public static final String HTTP_HEADER_DATALOG = "http.header.datalog";
-  
+
   /**
    * Comma separated list of ids which should be ignored by the forwarder. This is to prevent loops from
    * forming.
    */
   public static final String DATALOG_FORWARDER_IGNORED = "datalog.forwarder.ignored";
-  
+
   /**
    * Directory from which to read the datalog files to forward
    */
   public static final String DATALOG_FORWARDER_SRCDIR = "datalog.forwarder.srcdir";
-  
+
   /**
    * Directory where successfully forwarded files will be moved
    */
   public static final String DATALOG_FORWARDER_DSTDIR = "datalog.forwarder.dstdir";
-  
+
   /**
    * Flag used to indicate that forwarded requests should be deleted instead of moved.
    */
@@ -1328,38 +1333,38 @@ public class Configuration {
    * Delay between directory scans (in ms)
    */
   public static final String DATALOG_FORWARDER_PERIOD = "datalog.forwarder.period";
-  
+
   /**
    * Set to 'true' to compress forwarded update/meta requests
    */
   public static final String DATALOG_FORWARDER_COMPRESS = "datalog.forwarder.compress";
-  
+
   /**
    * Set to 'true' to act as a regular client when forwarding actions. Otherwise the datalog request will be forwarded.
    * This MUST be set to 'true' when forwarding to a distributed version of Warp 10.
    */
   public static final String DATALOG_FORWARDER_ACTASCLIENT = "datalog.forwarder.actasclient";
-  
+
   /**
    * Number of threads to spawn to handle datalog actions
    */
   public static final String DATALOG_FORWARDER_NTHREADS = "datalog.forwarder.nthreads";
-  
+
   /**
    * Endpoint to use when forwarding UPDATE actions
    */
   public static final String DATALOG_FORWARDER_ENDPOINT_UPDATE = "datalog.forwarder.endpoint.update";
-  
+
   /**
    * Endpoint to use when forwarding DELETE actions
-   */  
+   */
   public static final String DATALOG_FORWARDER_ENDPOINT_DELETE = "datalog.forwarder.endpoint.delete";
-  
+
   /**
    * Endpoint to use when forwarding META actions
    */
   public static final String DATALOG_FORWARDER_ENDPOINT_META = "datalog.forwarder.endpoint.meta";
-  
+
   /**
    * Set to 'true' to disable plasma
    */
@@ -1379,28 +1384,28 @@ public class Configuration {
    * Set to 'true' to indicate the instance will use memory only for storage. This type of instance is non persistent.
    */
   public static final String IN_MEMORY = "in.memory";
-  
+
   /**
    * Set to 'true' to use a chunked memory store.
    */
   public static final String IN_MEMORY_CHUNKED = "in.memory.chunked";
-  
+
   /**
    * Depth of timestamps to retain (in ms)
    */
   public static final String IN_MEMORY_DEPTH = "in.memory.depth";
-  
+
   /**
    * High water mark in bytes. When memory goes above this threshold, attempts to remove expired datapoints will be
    * done until consumed memory goes below the low water mark (see below) or no more expired datapoints can be found.
    */
   public static final String IN_MEMORY_HIGHWATERMARK = "in.memory.highwatermark";
-  
+
   /**
    * Low water mark in bytes for garbage collection (see above)
    */
   public static final String IN_MEMORY_LOWWATERMARK = "in.memory.lowwatermark";
-  
+
   /**
    * If set to true, then only the last recorded value of a GTS is kept
    */
@@ -1410,31 +1415,31 @@ public class Configuration {
    * Number of chunks per GTS to handle in memory (defaults to 3)
    */
   public static final String IN_MEMORY_CHUNK_COUNT = "in.memory.chunk.count";
-  
+
   /**
    * Length of each chunk (in time units), defaults to Long.MAX_VALUE
    */
   public static final String IN_MEMORY_CHUNK_LENGTH = "in.memory.chunk.length";
-  
+
   /**
    * Path to a dump file containing the state of an in-memory Warp 10 to restore.
    */
   public static final String STANDALONE_MEMORY_STORE_LOAD = "in.memory.load";
-  
+
   /**
    * Path to a dump file in which the current state of an in-memory Warp 10 will be persisted.
    */
   public static final String STANDALONE_MEMORY_STORE_DUMP = "in.memory.dump";
-  
+
   /**
    * How often (in ms) to perform a gc of the in-memory store.
    */
   public static final String STANDALONE_MEMORY_GC_PERIOD = "in.memory.gcperiod";
-  
+
   /**
-   * Maximum size (in bytes) of re-allocations performed during a gc cycle of the chunked in-memory store. 
+   * Maximum size (in bytes) of re-allocations performed during a gc cycle of the chunked in-memory store.
    */
-  public static final String STANDALONE_MEMORY_GC_MAXALLOC = "in.memory.gc.maxalloc";  
+  public static final String STANDALONE_MEMORY_GC_MAXALLOC = "in.memory.gc.maxalloc";
 
   /**
    * Set to 'true' to only forward data to Plasma. Not data storage will take place.
@@ -1444,7 +1449,7 @@ public class Configuration {
   //
   // E G R E S S
   //
-  
+
   /**
    * Comma separated list of Egress related HBase configuration keys to extract from the Warp 10 configuration.
    * The listed keys will be extracted from 'egress.' prefixed configuration keys.
@@ -1455,42 +1460,42 @@ public class Configuration {
    * Port onto which the egress server should listen
    */
   public static final String EGRESS_PORT = "egress.port";
-  
+
   /**
    * Host onto which the egress server should listen
    */
   public static final String EGRESS_HOST = "egress.host";
-  
+
   /**
    * Number of acceptors
    */
   public static final String EGRESS_ACCEPTORS = "egress.acceptors";
-  
+
   /**
    * Number of selectors
    */
   public static final String EGRESS_SELECTORS = "egress.selectors";
-  
+
   /**
    * Idle timeout
    */
   public static final String EGRESS_IDLE_TIMEOUT = "egress.idle.timeout";
-  
+
   /**
    * ZooKeeper server list
    */
   public static final String EGRESS_ZK_QUORUM = "egress.zk.quorum";
-  
+
   /**
    * Key to use for encrypting GTSSplit instances
    */
   public static final String EGRESS_FETCHER_AES = "egress.fetcher.aes";
-  
+
   /**
    * Maximum age of a valid GTSSplit (in ms)
    */
   public static final String EGRESS_FETCHER_MAXSPLITAGE = "egress.fetcher.maxsplitage";
-  
+
   /**
    * Custom value of 'hbase.client.ipc.pool.size' for the Egress HBase pool
    */
@@ -1505,22 +1510,22 @@ public class Configuration {
    * Custom value of 'hbase.client.max.perserver.tasks', defaults to 2
    */
   public static final String EGRESS_HBASE_CLIENT_MAX_PERSERVER_TASKS = "egress.hbase.client.max.perserver.tasks";
-  
+
   /**
    * Custom value of 'hbase.client.max.perregion.tasks', defaults to 1
    */
   public static final String EGRESS_HBASE_CLIENT_MAX_PERREGION_TASKS = "egress.hbase.client.max.perregion.tasks";
-  
+
   /**
    * Custom value of 'hbase.client.max.total.tasks', defaults to 100
    */
   public static final String EGRESS_HBASE_CLIENT_MAX_TOTAL_TASKS = "egress.hbase.client.max.total.tasks";
-  
+
   /**
    * Custom value for RPC timeout
    */
   public static final String EGRESS_HBASE_RPC_TIMEOUT = "egress.hbase.rpc.timeout";
-  
+
   /**
    * Number of threads to use for scheduling parallel scanners. Use 0 to disable parallel scanners
    */
@@ -1536,10 +1541,10 @@ public class Configuration {
    * parallel scanners will be spawned. Defaults to 4.
    */
   public static final String EGRESS_HBASE_PARALLELSCANNERS_MIN_GTS_PERSCANNER = "egress.hbase.parallelscanners.min.gts.perscanner";
-  
+
   /**
    * Maximum number of parallel scanners to use when fetching datapoints for a batch of GTS (see EGRESS_FETCH_BATCHSIZE).
-   * Defaults to 16. 
+   * Defaults to 16.
    */
   public static final String EGRESS_HBASE_PARALLELSCANNERS_MAX_PARALLEL_SCANNERS = "egress.hbase.parallelscanners.max.parallel.scanners";
 
@@ -1558,10 +1563,10 @@ public class Configuration {
    * parallel scanners will be spawned. Defaults to 4.
    */
   public static final String STANDALONE_PARALLELSCANNERS_MIN_GTS_PERSCANNER = "standalone.parallelscanners.min.gts.perscanner";
-  
+
   /**
    * Maximum number of parallel scanners to use when fetching datapoints for a batch of GTS (see EGRESS_FETCH_BATCHSIZE) in the standalone version.
-   * Defaults to 16. 
+   * Defaults to 16.
    */
   public static final String STANDALONE_PARALLELSCANNERS_MAX_PARALLEL_SCANNERS = "standalone.parallelscanners.max.parallel.scanners";
 
@@ -1570,22 +1575,22 @@ public class Configuration {
    * The goal is to limit the cache pollution when scanning large chunks of data.
    */
   public static final String EGRESS_HBASE_DATA_BLOCKCACHE_GTS_THRESHOLD = "egress.hbase.data.blockcache.gts.threshold";
-  
+
   /**
-   * Key to use for encrypting data in HBase (128/192/256 bits in hex or OSS reference) 
+   * Key to use for encrypting data in HBase (128/192/256 bits in hex or OSS reference)
    */
   public static final String EGRESS_HBASE_DATA_AES = "egress.hbase.data.aes";
-  
+
   /**
    * Columns family under which data should be stored
    */
   public static final String EGRESS_HBASE_DATA_COLFAM = "egress.hbase.data.colfam";
-  
+
   /**
    * HBase table where data should be stored
    */
   public static final String EGRESS_HBASE_DATA_TABLE = "egress.hbase.data.table";
-  
+
   /**
    * ZooKeeper Quorum for locating HBase
    */
@@ -1605,28 +1610,28 @@ public class Configuration {
    * Number of GTS to batch when retrieving datapoints (to mitigate responseTooSlow errors)
    */
   public static final String EGRESS_FETCH_BATCHSIZE = "egress.fetch.batchsize";
-  
+
   /**
    * Boolean indicating whether or not to use the HBase filter when retrieving rows.
    */
   public static final String EGRESS_HBASE_FILTER = "egress.hbase.filter";
-  
+
   /**
    * GTS count threshold above which the filter will be used.
    */
   public static final String EGRESS_HBASE_FILTER_THRESHOLD = "egress.hbase.filter.threshold";
-  
+
   //
   // T H R O T T L I N G    M A N A G E R
   //
   /////////////////////////////////////////////////////////////////////////////////////////
-  
+
   /**
    * Name of system property (configuration property) which contains the
    * root directory where throttle files are stored.
-   */  
+   */
   public static final String THROTTLING_MANAGER_DIR = "throttling.manager.dir";
-  
+
   /**
    * Period (in ms) between two scans of the THROTTLING_MANAGER_DIR
    */
@@ -1639,12 +1644,12 @@ public class Configuration {
    * we just restarted.
    */
   public static final String THROTTLING_MANAGER_RAMPUP = "throttling.manager.rampup";
-  
+
   /**
    * Maximum number of estimators we keep in memory
    */
   public static final String THROTTLING_MANAGER_ESTIMATOR_CACHE_SIZE = "throttling.manager.estimator.cache.size";
-  
+
   /**
    * Default value for the rate when not configured through a file
    */
@@ -1664,12 +1669,12 @@ public class Configuration {
   // G E O D I R
   //
   /////////////////////////////////////////////////////////////////////////////////////////
-  
+
   /**
    * Prefix to use if dumping/loading the LKP indices
    */
   public static final String GEODIR_DUMP_PREFIX = "geodir.dump.prefix";
-  
+
   public static final String GEODIR_KAFKA_SUBS_ZKCONNECT = "geodir.kafka.subs.zkconnect";
   public static final String GEODIR_KAFKA_SUBS_BROKERLIST = "geodir.kafka.subs.brokerlist";
   public static final String GEODIR_KAFKA_SUBS_PRODUCER_CLIENTID = "geodir.kafka.subs.producer.clientid";
@@ -1702,7 +1707,7 @@ public class Configuration {
   public static final String GEODIR_KAFKA_DATA_MAC = "geodir.kafka.data.mac";
   public static final String GEODIR_KAFKA_DATA_AES = "geodir.kafka.data.aes";
   public static final String GEODIR_KAFKA_DATA_MAXSIZE = "geodir.kafka.data.maxsize";
-  
+
   public static final String GEODIR_ID = "geodir.id";
   public static final String GEODIR_NAME = "geodir.name";
   public static final String GEODIR_MODULUS = "geodir.modulus";
@@ -1724,31 +1729,31 @@ public class Configuration {
   public static final String GEODIR_DIRECTORY_PSK = "geodir.directory.psk";
   public static final String GEODIR_FETCH_PSK = "geodir.fetch.psk";
   public static final String GEODIR_FETCH_ENDPOINT = "geodir.fetch.endpoint";
-  
+
   public static final String GEODIR_ZK_SUBS_QUORUM = "geodir.zk.subs.quorum";
   public static final String GEODIR_ZK_SUBS_ZNODE = "geodir.zk.subs.znode";
   public static final String GEODIR_ZK_SUBS_MAXZNODESIZE = "geodir.zk.subs.maxznodesize";
   public static final String GEODIR_ZK_SUBS_AES = "geodir.zk.subs.aes";
-  
+
   public static final String GEODIR_ZK_PLASMA_QUORUM = "geodir.zk.plasma.quorum";
   public static final String GEODIR_ZK_PLASMA_ZNODE = "geodir.zk.plasma.znode";
   public static final String GEODIR_ZK_PLASMA_MAXZNODESIZE = "geodir.zk.plasma.maxznodesize";
-  
+
   public static final String GEODIR_ZK_SERVICE_QUORUM = "geodir.zk.service.quorum";
   public static final String GEODIR_ZK_SERVICE_ZNODE = "geodir.zk.service.znode";
-  
+
   public static final String GEODIR_ZK_DIRECTORY_QUORUM = "geodir.zk.directory.quorum";
   public static final String GEODIR_ZK_DIRECTORY_ZNODE = "geodir.zk.directory.znode";
-  
+
   /**
    * Comma separated list of GeoDirectory instances to maintain.
    * Each instance is defined by a string with the following format:
-   * 
+   *
    * name/resolution/chunks/chunkdepth
-   * 
+   *
    * name is the name of the GeoDirectory
    * resolution is a number between 1 and 15 defining the resolution of the geo index:
-   * 
+   *
    * 1 = 10,000 km
    * 2 =  2,500 km
    * 3 =    625 km
@@ -1760,71 +1765,71 @@ public class Configuration {
    * 9 =    153 m
    * 10=     38 m
    * 11=     10 m
-   * 12=    238 cm 
+   * 12=    238 cm
    * 13=     60 cm
    * 14=     15 cm
    * 15=      4 cm
-   * 
+   *
    * chunks is the number of time chunks to maintain
    * chunkdepth is the time span of each time chunk, in ms
    */
   public static final String STANDALONE_GEODIRS = "standalone.geodirs";
-  
+
   /**
    * Delay in ms between two subscription updates
    */
   public static final String STANDALONE_GEODIR_DELAY = "standalone.geodir.delay";
-  
+
   /**
    * Maximum number of 'cells' in the query area, system will attempt to reduce the number
    * of cells searched by replacing small cells with their enclosing parent until the number
    * of cells falls below this maximum or no more simplification can be done.
-   * 
+   *
    * A good value for performance is around 256
    */
   public static final String STANDALONE_GEODIR_MAXCELLS = "standalone.geodir.maxcells";
-  
+
   /**
    * AES encryption key for subscriptions
    */
   public static final String STANDALONE_GEODIR_AES = "standalone.geodir.aes";
-  
+
   /**
    * Directory where subscriptions should be stored
    */
   public static final String STANDALONE_GEODIR_SUBS_DIR = "standalone.geodir.subs.dir";
-  
+
   /**
    * Prefix for subscription files
    */
   public static final String STANDALONE_GEODIR_SUBS_PREFIX = "standalone.geodir.subs.prefix";
-  
+
   /////////////////////////////////////////////////////////////////////////////////////////
 
   //
   // Jar Repository
   //
-  
+
   public static final String JARS_DIRECTORY = "warpscript.jars.directory";
   public static final String JARS_REFRESH = "warpscript.jars.refresh";
   public static final String JARS_FROMCLASSPATH = "warpscript.jars.fromclasspath";
-  
+
   /*
    * CALL root directory property
    */
-  
+
   public static final String WARPSCRIPT_CALL_DIRECTORY = "warpscript.call.directory";
-  
+
   /**
    * Maximum number of subprogram instances which can be spawned
    */
   public static final String WARPSCRIPT_CALL_MAXCAPACITY = "warpscript.call.maxcapacity";
-      
+
   /**
    * Macro Repository root directory
-   */  
+   */
   public static final String REPOSITORY_DIRECTORY = "warpscript.repository.directory";
-  
+
   /**
    * Macro repository refresh interval (in ms)
    */
@@ -1842,19 +1847,19 @@ public class Configuration {
 
   /**
    * HTTP Header for elapsed time of WarpScript scripts
-   */  
+   */
   public static final String HTTP_HEADER_ELAPSEDX = "http.header.elapsed";
 
   /**
    * HTTP Header for number of ops performed in a script invocation
    */
   public static final String HTTP_HEADER_OPSX = "http.header.ops";
-  
+
   /**
    * HTTP Header for number of datapoints fetched during a script invocation
    */
   public static final String HTTP_HEADER_FETCHEDX = "http.header.fetched";
-  
+
   /**
    * Script line where an error was encountered
    */
@@ -1895,12 +1900,12 @@ public class Configuration {
    * HTTP Header for specifying the timespan in /sfetch requests
    */
   public static final String HTTP_HEADER_TIMESPAN_HEADERX = "http.header.timespan";
-  
+
   /**
    * HTTP Header to specify if we should show errors in /sfetch responses
    */
   public static final String HTTP_HEADER_SHOW_ERRORS_HEADERX = "http.header.showerrors";
-  
+
   /**
    * Name of header containing the signature of the token used for the fetch
    */
@@ -1910,15 +1915,15 @@ public class Configuration {
    * Name of header containing the signature of the token used for the update
    */
   public static String HTTP_HEADER_UPDATE_SIGNATURE = "http.header.update.signature";
-  
+
   /**
    * Name of header containing the signature of streaming directory requests
    */
-  public static String HTTP_HEADER_DIRECTORY_SIGNATURE = "http.header.directory.signature";  
+  public static String HTTP_HEADER_DIRECTORY_SIGNATURE = "http.header.directory.signature";
 
   /**
    * Name of header containing the name of the symbol in which to expose the request headers
    */
   public static String HTTP_HEADER_EXPOSE_HEADERS = "http.header.exposeheaders";
-  
+
 }

--- a/warp10/src/main/java/io/warp10/continuum/sensision/SensisionConstants.java
+++ b/warp10/src/main/java/io/warp10/continuum/sensision/SensisionConstants.java
@@ -19,17 +19,17 @@ package io.warp10.continuum.sensision;
 import io.warp10.sensision.Sensision;
 
 public class SensisionConstants {
-  
+
   static {
     if (null == System.getProperty(Sensision.SENSISION_INSTANCE)) {
       Sensision.setInstance("warp");
     }
   }
-  
+
   //
   // Classes
   //
-  
+
   /**
    * Number of datalog requests which were forwarded successfully
    */
@@ -71,12 +71,12 @@ public class SensisionConstants {
   public static final String CLASS_WARP_INGRESS_DELETE_ERRORS = "warp.ingress.delete.errors";
 
   /**
-   * Number of TimeSource calibrations  
+   * Number of TimeSource calibrations
    */
   public static final String CLASS_WARP_TIMESOURCE_CALIBRATIONS = "warp.timesource.calibrations";
 
   /**
-   * Number of skipped TimeSource calibrations  
+   * Number of skipped TimeSource calibrations
    */
   public static final String SENSISION_CLASS_WARP_TIMESOURCE_CALIBRATIONS_SKIPPED = "warp.timesource.calibrations.skipped";
 
@@ -84,12 +84,12 @@ public class SensisionConstants {
    * Revision of components
    */
   public static final String SENSISION_CLASS_WARP_REVISION = "warp.revision";
-  
+
   /**
-   * Number of entries in the serialized metadata cache 
+   * Number of entries in the serialized metadata cache
    */
   public static final String CLASS_WARP_DIRECTORY_METADATA_CACHE_SIZE = "warp.directory.metadata.cache.size";
-  
+
   /**
    * Number of hits in the serialized metadata cache
    */
@@ -104,7 +104,7 @@ public class SensisionConstants {
    * Number of collisions detected for labels Id
    */
   public static final String CLASS_WARP_DIRECTORY_LABELS_COLLISIONS = "warp.directory.labels.collisions";
-  
+
   /**
    * Number of GTS metadata managed by Directory.
    */
@@ -116,25 +116,25 @@ public class SensisionConstants {
   public static final String SENSISION_CLASS_CONTINUUM_DIRECTORY_CLASSES = "warp.directory.classes";
 
   /**
-   * Number of distinct owners known by a Directory
+   * Number of split handle by a Directory
    */
-  public static final String SENSISION_CLASS_CONTINUUM_DIRECTORY_OWNERS = "warp.directory.owners";
+  public static final String SENSISION_CLASS_CONTINUUM_DIRECTORY_SPLITS = "warp.directory.splits";
 
   /**
    * Number of times the Thrift directory client cache was changed
    */
   public static final String SENSISION_CLASS_CONTINUUM_DIRECTORY_CLIENT_CACHE_CHANGED = "warp.directory.client.cache.changed";
-  
+
   /**
    * Free memory for directory
    */
   public static final String SENSISION_CLASS_CONTINUUM_DIRECTORY_JVM_FREEMEMORY = "warp.directory.jvm.freememory";
-  
+
   /**
    * Number of calls to the fetch method of the store client
    */
   public static final String SENSISION_CLASS_CONTINUUM_FETCH_COUNT = "warp.fetch.count";
-  
+
   /**
    * Number of value bytes read by the calls to fetch
    */
@@ -234,37 +234,37 @@ public class SensisionConstants {
    * Number of messages sent on the throttling topic
    */
   public static final String CLASS_WARP_INGRESS_KAFKA_THROTTLING_OUT_MESSAGES = "warp.ingress.kafka.throttling.out.messages";
-  
+
   /**
    * Number of bytes sent on the throttling topic
    */
   public static final String CLASS_WARP_INGRESS_KAFKA_THROTTLING_OUT_BYTES = "warp.ingress.kafka.throttling.out.bytes";
-  
+
   /**
    * Number of errors encountered while sending on the throttling topic
    */
   public static final String CLASS_WARP_INGRESS_KAFKA_THROTTLING_ERRORS = "warp.ingress.kafka.throttling.error";
-  
+
   /**
    * Number of messages consumed from the throttling topic
    */
   public static final String CLASS_WARP_INGRESS_KAFKA_THROTTLING_IN_MESSAGES = "warp.ingress.kafka.throttling.in.messages";
-  
+
   /**
    * Number of bytes consumed from the throttling topic
    */
   public static final String CLASS_WARP_INGRESS_KAFKA_THROTTLING_IN_BYTES = "warp.ingress.kafka.throttling.in.bytes";
-    
+
   /**
    * Number of invalid MACs encountered while consuming the throttling topic
    */
   public static final String CLASS_WARP_INGRESS_KAFKA_THROTTLING_IN_INVALIDMACS = "warp.ingress.kafka.throttling.in.invalidmacs";
-  
+
   /**
    * Number of successful throttling estimators fusions
    */
   public static final String CLASS_WARP_INGRESS_THROTLLING_FUSIONS = "warp.ingress.throttling.fusions";
-  
+
   /**
    * Number of failed throttling estimators fusions
    */
@@ -274,17 +274,17 @@ public class SensisionConstants {
    * Number of Metadata cached in 'ingress'
    */
   public static final String SENSISION_CLASS_CONTINUUM_INGRESS_METADATA_CACHED = "warp.ingress.metadata.cached";
-  
+
   /**
    * Number of Kafka messages containing data produced by 'Ingress'
    */
   public static final String SENSISION_CLASS_CONTINUUM_INGRESS_KAFKA_DATA_MESSAGES = "warp.ingress.kafka.data.messages";
-  
+
   /**
    * Number of calls to Kafka send by 'Ingress' for messages containing data
    */
   public static final String SENSISION_CLASS_CONTINUUM_INGRESS_KAFKA_DATA_SEND = "warp.ingress.kafka.data.send";
-  
+
   /**
    * Number of Producer get from the producer pool
    */
@@ -319,7 +319,7 @@ public class SensisionConstants {
    * Number of Kafka delete messages produced by 'Ingress'
    */
   public static final String SENSISION_CLASS_CONTINUUM_INGRESS_KAFKA_DELETE_MESSAGES = "warp.ingress.kafka.delete.messages";
-  
+
   /**
    * Number of calls to Kafka send by 'Ingress' for deletion messages
    */
@@ -329,12 +329,12 @@ public class SensisionConstants {
    * Number of Kafka messages containing data produced by 'Ingress'
    */
   public static final String SENSISION_CLASS_CONTINUUM_INGRESS_KAFKA_META_MESSAGES = "warp.ingress.kafka.meta.messages";
-  
+
   /**
    * Number of calls to Kafka send by 'Ingress' for messages containing metadata
    */
   public static final String SENSISION_CLASS_CONTINUUM_INGRESS_KAFKA_META_SEND = "warp.ingress.kafka.meta.send";
-  
+
   /**
    * Number of messages consumed from the 'metadata' Kafka topic by 'Ingress'
    */
@@ -379,17 +379,17 @@ public class SensisionConstants {
    * Number of times an 'update' request was done using an invalid token
    */
   public static final String SENSISION_CLASS_CONTINUUM_INGRESS_UPDATE_INVALIDTOKEN = "warp.ingress.update.invalidtoken";
-  
+
   /**
    * Number of 'update' requests which had gzipped content
    */
   public static final String SENSISION_CLASS_CONTINUUM_INGRESS_UPDATE_GZIPPED = "warp.ingress.update.gzipped";
-  
+
   /**
    * Number of parse error encountered in Ingress 'update' requests
    */
   public static final String SENSISION_CLASS_CONTINUUM_INGRESS_UPDATE_PARSEERRORS = "warp.ingress.update.parseerrors";
-    
+
   /**
    * Number of raw readings pushed into Continuum
    */
@@ -414,22 +414,22 @@ public class SensisionConstants {
    * Number of 'meta' requests to the Ingress component
    */
   public static final String SENSISION_CLASS_CONTINUUM_INGRESS_META_REQUESTS = "warp.ingress.meta.requests";
-  
+
   /**
    * Number of times a 'meta' request was done using an invalid token
    */
   public static final String SENSISION_CLASS_CONTINUUM_INGRESS_META_INVALIDTOKEN = "warp.ingress.meta.invalidtoken";
-  
+
   /**
    * Number of 'meta' requests which had gzipped content
    */
   public static final String SENSISION_CLASS_CONTINUUM_INGRESS_META_GZIPPED = "warp.ingress.meta.gzipped";
-  
+
   /**
    * Number of times invalid metadata were sent to the 'meta' endpoint of Ingress
    */
   public static final String SENSISION_CLASS_CONTINUUM_INGRESS_META_INVALID = "warp.ingress.meta.invalid";
-  
+
   /**
    * Number of metadata records sent to the 'meta' endpoint of Ingress
    */
@@ -469,7 +469,7 @@ public class SensisionConstants {
    * Time spent in microsesonds in standalone 'delete'
    */
   public static final String SENSISION_CLASS_CONTINUUM_STANDALONE_DELETE_TIME_US = "warp.standalone.delete.time.us";
-      
+
   /**
    * Number of microseconds spent in 'update' in the standalone version of Continuum
    */
@@ -496,7 +496,7 @@ public class SensisionConstants {
   public static final String SENSISION_CLASS_CONTINUUM_STANDALONE_STREAM_UPDATE_REQUESTS = "warp.standalone.update.stream.requests";
 
   /*
-   * Number of snapshot requests made to the standalone storage layer 
+   * Number of snapshot requests made to the standalone storage layer
    */
   public static final String SENSISION_CLASS_WARP_STANDALONE_LEVELDB_SNAPSHOT_REQUESTS = "warp.standalone.leveldb.snapshot.requests";
 
@@ -504,7 +504,7 @@ public class SensisionConstants {
    * Time spent with compactions disabled to enable snapshots
    */
   public static final String SENSISION_CLASS_WARP_STANDALONE_LEVELDB_SNAPSHOT_TIME_NS = "warp.standalone.leveldb.snapshot.time.ns";
-  
+
   /**
    * Number of 'update' requests received by the streaming version of continuum
    */
@@ -566,10 +566,10 @@ public class SensisionConstants {
   public static final String SENSISION_CLASS_CONTINUUM_STORE_HBASE_PUTS_COMMITTED = "warp.store.hbase.puts.committed";
 
   /**
-   * Number of GTSDecoders handled by 'Store'  
+   * Number of GTSDecoders handled by 'Store'
    */
   public static final String SENSISION_CLASS_CONTINUUM_STORE_GTSDECODERS = "warp.store.gtsdecoders";
-  
+
   /**
    * Number of calls to 'flushCommits' done in 'Store'
    */
@@ -579,32 +579,32 @@ public class SensisionConstants {
    * Time spend writing to HBase in 'Store'
    */
   public static final String SENSISION_CLASS_CONTINUUM_STORE_HBASE_TIME_NANOS = "warp.store.hbase.time.nanos";
-  
+
   /**
    * Number of barrier synchronizations
    */
   public static final String SENSISION_CLASS_CONTINUUM_STORE_BARRIER_SYNCS = "warp.store.barrier.syncs";
-  
+
   /**
    * Number of Kafka offset commits done in 'Store'
    */
   public static final String SENSISION_CLASS_CONTINUUM_STORE_KAFKA_COMMITS = "warp.store.kafka.commits";
-  
+
   /**
    * Number of Kafka messages read in 'Store'
    */
   public static final String SENSISION_CLASS_CONTINUUM_STORE_KAFKA_COUNT = "warp.store.kafka.count";
-  
+
   /**
    * Number of Kafka messages bytes read in 'Store'
    */
   public static final String SENSISION_CLASS_CONTINUUM_STORE_KAFKA_BYTES = "warp.store.kafka.bytes";
-  
+
   /**
    * Number of failed MAC verification for Kafka messages read in 'Store'
    */
   public static final String SENSISION_CLASS_CONTINUUM_STORE_KAFKA_FAILEDMACS = "warp.store.kafka.failedmacs";
-  
+
   /**
    * Number of failed decryptions for Kafka messages read in 'Store'
    */
@@ -614,28 +614,28 @@ public class SensisionConstants {
    * Number of aborts experienced in 'Store'
    */
   public static final String SENSISION_CLASS_CONTINUUM_STORE_ABORTS = "warp.store.aborts";
-  
+
   /**
    * Number of times commits were overdue, probably due to a call to htable.batch having hang
    */
   public static final String CLASS_WARP_STORE_KAFKA_COMMITS_OVERDUE = "warp.store.kafka.commits.overdue";
-  
+
   /**
    * Number of times the HBase connection was reset. This is a total number across all Store instances within a JVM.
    */
   public static final String CLASS_WARP_STORE_HBASE_CONN_RESETS = "warp.store.hbase.conn.resets";
-  
+
   /**
    * Rate at which we throttle the Kafka consumers. This rate is used by generating a random number and only
    * process an incoming message if that number is <= CLASS_WARP_STORE_THROTTLING_RATE
    */
   public static final String CLASS_WARP_STORE_THROTTLING_RATE = "warp.store.throttling.rate";
-  
+
   /**
    * Time spent in DELETE ops in 'Store'
    */
   public static final String SENSISION_CLASS_CONTINUUM_STORE_HBASE_DELETE_TIME_NANOS = "warp.store.hbase.delete.time.nanos";
-  
+
   /**
    * Number of DELETE ops handled by 'Store'
    */
@@ -680,12 +680,12 @@ public class SensisionConstants {
    * Number of HBase scanners which used a filter (SlicedRowFilter)
    */
   public static final String SENSISION_CLASS_CONTINUUM_HBASE_CLIENT_FILTERED_SCANNERS = "warp.hbase.client.scanners.filtered";
-  
+
   /**
    * Number of ranges filtered by the filtered scanners
    */
   public static final String SENSISION_CLASS_CONTINUUM_HBASE_CLIENT_FILTERED_SCANNERS_RANGES = "warp.hbase.client.scanners.filtered.ranges";
-  
+
   /**
    * Number of optimized scanners created
    */
@@ -729,7 +729,7 @@ public class SensisionConstants {
    * Number of failed MAC verification for Kafka messages read in 'Directory'
    */
   public static final String SENSISION_CLASS_CONTINUUM_DIRECTORY_KAFKA_FAILEDMACS = "warp.directory.kafka.failedmacs";
-  
+
   /**
    * Number of failed decryptions for Kafka messages read in 'Directory'
    */
@@ -794,7 +794,7 @@ public class SensisionConstants {
    * Number of expired streaming requests
    */
   public static final String SENSISION_CLASS_CONTINUUM_DIRECTORY_STREAMING_EXPIRED = "warp.directory.streaming.expired";
-  
+
   /**
    * Number of successful streaming requests
    */
@@ -809,7 +809,7 @@ public class SensisionConstants {
    * Number of streaming results
    */
   public static final String SENSISION_CLASS_CONTINUUM_DIRECTORY_STREAMING_RESULTS = "warp.directory.streaming.results";
-  
+
   /**
    * Expired stats requests
    */
@@ -869,37 +869,37 @@ public class SensisionConstants {
    * Number of times the Einstein bootstrap code was loaded
    */
   public static final String SENSISION_CLASS_EINSTEIN_BOOTSTRAP_LOADS = "warp.script.bootstrap.loads";
-  
+
   /**
    * Number of Einstein requests
    */
   public static final String SENSISION_CLASS_EINSTEIN_REQUESTS = "warp.script.requests";
-  
+
   /**
    * Total time (us) spent in Einstein requests
    */
   public static final String SENSISION_CLASS_EINSTEIN_TIME_US = "warp.script.time.us";
-  
+
   /**
    * Total number of ops in Einstein scripts
    */
   public static final String SENSISION_CLASS_EINSTEIN_OPS = "warp.script.ops";
-  
+
   /**
    * Total number of errors in Einstein scripts
    */
-  public static final String SENSISION_CLASS_EINSTEIN_ERRORS = "warp.script.errors";  
+  public static final String SENSISION_CLASS_EINSTEIN_ERRORS = "warp.script.errors";
 
   /**
    * Free memory reported by the JVM
    */
   public static final String SENSISION_CLASS_EINSTEIN_JVM_FREEMEMORY = "warp.script.jvm.freememory";
-  
+
   /**
    * Number of uses of a given Einstein function
    */
   public static final String SENSISION_CLASS_EINSTEIN_FUNCTION_COUNT = "warp.script.function.count";
-  
+
   /**
    * Number of times the stack depth limit was reached
    */
@@ -934,7 +934,7 @@ public class SensisionConstants {
    * Number of current active executions
    */
   public static final String SENSISION_CLASS_EINSTEIN_RUN_CURRENT = "warp.script.run.current";
-  
+
   /**
    * Total time spent running a given script
    */
@@ -949,17 +949,17 @@ public class SensisionConstants {
    * Elapsed time per scheduled script
    */
   public static final String SENSISION_CLASS_EINSTEIN_RUN_ELAPSED = "warp.script.run.elapsed.ns";
-  
+
   /**
    * Number of ops per scheduled script
    */
   public static final String SENSISION_CLASS_EINSTEIN_RUN_OPS = "warp.script.run.ops";
-  
+
   /**
    * Number of datapoints fetched per scheduled script
    */
   public static final String SENSISION_CLASS_EINSTEIN_RUN_FETCHED = "warp.script.run.fetched";
-  
+
   /**
    * Number of sessions with macros currently scheduled by Mobius
    */
@@ -984,7 +984,7 @@ public class SensisionConstants {
    * Number of shards dropped by the GC since the launch of the platform instance
    */
   public static final String SENSISION_CLASS_CONTINUUM_STANDALONE_INMEMORY_GC_CHUNKS = "warp.standalone.inmemory.gc.chunks";
-  
+
   /**
    * Number of points currently stored in the memory store
    */
@@ -1009,7 +1009,7 @@ public class SensisionConstants {
    * Number of bytes reclaimed by shrinking arrays backing buffers.
    */
   public static final String SENSISION_CLASS_CONTINUUM_STANDALONE_INMEMORY_GC_RECLAIMED = "warp.standalone.inmemory.gc.reclaimed";
-  
+
   /**
    * Number of datapoints garbage collected in the memory store
    */
@@ -1026,10 +1026,10 @@ public class SensisionConstants {
   public static final String SENSISION_CLASS_CONTINUUM_ESTIMATORS_CACHED_PER_APP = "warp.estimators.cached.perapp";
 
   /**
-   * Number of invalid hashes detected when 
+   * Number of invalid hashes detected when
    */
   public static final String SENSISION_CLASS_PLASMA_BACKEND_SUBSCRIPTIONS_INVALID_HASHES = "warp.plasma.backend.subscriptions.invalid.hashes";
-  
+
   /**
    * Number of subscriptions (GTS) by backend
    */
@@ -1069,7 +1069,7 @@ public class SensisionConstants {
    * Number of bytes buffered outwards
    */
   public static final String SENSISION_CLASS_PLASMA_BACKEND_KAFKA_OUT_BYTES = "warp.plasma.backend.kafka.out.bytes";
-  
+
   /**
    * Number of send ops by the outward kafka producer
    */
@@ -1079,22 +1079,22 @@ public class SensisionConstants {
    * Number of failed MAC checks
    */
   public static final String SENSISION_CLASS_PLASMA_FRONTEND_KAFKA_INVALIDMACS = "warp.plasma.frontend.kafka.invalidmacs";
-  
+
   /**
    * Number of failed decipherments
    */
   public static final String SENSISION_CLASS_PLASMA_FRONTEND_KAFKA_INVALIDCIPHERS = "warp.plasma.frontend.kafka.invalidciphers";
-  
+
   /**
-   * Number of Kafka messages consumed by Plasma Frontend 
+   * Number of Kafka messages consumed by Plasma Frontend
    */
   public static final String SENSISION_CLASS_PLASMA_FRONTEND_KAFKA_MESSAGES = "warp.plasma.frontend.kafka.messages";
-  
+
   /**
    * Number of bytes consumed by Plasma Frontend
    */
   public static final String SENSISION_CLASS_PLASMA_FRONTEND_KAFKA_BYTES = "warp.plasma.frontend.kafka.bytes";
-  
+
   /**
    * Number of Kafka consuming loop abortions
    */
@@ -1109,12 +1109,12 @@ public class SensisionConstants {
    * Number of barrier synchronizations
    */
   public static final String SENSISION_CLASS_PLASMA_FRONTEND_SYNCS = "warp.plasma.frontend.syncs";
-  
+
   /**
    * Number of GTS subscribed to by Plasma Front End
    */
   public static final String SENSISION_CLASS_PLASMA_FRONTEND_SUBSCRIPTIONS = "warp.plasma.frontend.subscriptions";
-  
+
   /**
    * Number of calls to dispatch
    */
@@ -1129,12 +1129,12 @@ public class SensisionConstants {
    * Time (in miroseconds) spent in 'dispatch'
    */
   public static final String SENSISION_CLASS_PLASMA_FRONTEND_DISPATCH_TIME_US = "warp.plasma.frontend.dispatch.time.ns";
-  
+
   /**
    * Number of distinct GTS as estimated by HLL+
    */
   public static final String SENSISION_CLASS_CONTINUUM_GTS_DISTINCT = "warp.gts.distinct";
-  
+
   /**
    * Number of distinct GTS as estimated by HLL+ per application
    */
@@ -1159,7 +1159,7 @@ public class SensisionConstants {
    * Number of times the distinct GTS throttling triggered globally
    */
   public static final String SENSISION_CLASS_CONTINUUM_THROTTLING_GTS_GLOBAL = "warp.throttling.gts.global";
-  
+
   /**
    * MADS per producer
    */
@@ -1214,47 +1214,47 @@ public class SensisionConstants {
    * Number of macros known in the repository
    */
   public static final String SENSISION_CLASS_EINSTEIN_REPOSITORY_MACROS = "warp.script.repository.macros";
-  
+
   /**
    * Number of jar files known in the repository
    */
   public static final String SENSISION_CLASS_EINSTEIN_REPOSITORY_JARS = "warp.script.repository.jars";
-  
+
   /**
    * Number of messages consumed from Kafka
    */
   public static final String SENSISION_CLASS_WEBCALL_KAFKA_IN_COUNT = "warp.webcall.kafka.in.count";
-  
+
   /**
    * Number of bytes consumed from Kafka
    */
   public static final String SENSISION_CLASS_WEBCALL_KAFKA_IN_BYTES = "warp.webcall.kafka.in.bytes";
-  
+
   /**
    * Number of MAC verification failures
    */
   public static final String SENSISION_CLASS_WEBCALL_KAFKA_IN_FAILEDMACS = "warp.webcall.kafka.in.failedmacs";
-  
+
   /**
    * Number of unwrapping failures
    */
   public static final String SENSISION_CLASS_WEBCALL_KAFKA_IN_FAILEDDECRYPTS = "warp.webcall.kafka.in.faileddecrypts";
-  
+
   /**
    * Total latency of WebCallRequests handling
    */
   public static final String SENSISION_CLASS_WEBCALL_LATENCY_MS = "warp.webcall.latency.ms";
-  
+
   /**
    * Number of offset commits
    */
   public static final String SENSISION_CLASS_WEBCALL_KAFKA_IN_COMMITS = "warp.webcall.kafka.in.commits";
-  
+
   /**
    * Number of consuming loop abortions
    */
   public static final String SENSISION_CLASS_WEBCALL_IN_ABORTS = "warp.webcall.kafka.in.aborts";
-  
+
   /**
    * Number of barrier synchronizations
    */
@@ -1290,22 +1290,22 @@ public class SensisionConstants {
   public static final String SENSISION_CLASS_GEODIR_DATA_KAFKA_OUT_MESSAGES = "warp.geodir.data.kafka.out.messages";
   public static final String SENSISION_CLASS_GEODIR_DATA_KAFKA_OUT_BYTES = "warp.geodir.data.kafka.out.bytes";
   public static final String SENSISION_CLASS_GEODIR_FETCH_FAILEDDESER = "warp.geodir.fetch.faileddeser";
-  
+
   /**
    * Kafka Consumer Offset
    */
   public static final String SENSISION_CLASS_WARP_KAFKA_CONSUMER_OFFSET = "warp.kafka.consumer.offset";
-  
+
   /**
    * Number of messages which were more than 1 message ahead of the previously consumed (or committed) message
    */
   public static final String SENSISION_CLASS_WARP_KAFKA_CONSUMER_OFFSET_FORWARD_LEAPS = "warp.kafka.consumer.forward.leaps";
-  
+
   /**
    * Number of messages which were in the past relative to the previously committed message offset
    */
   public static final String SENSISION_CLASS_WARP_KAFKA_CONSUMER_OFFSET_BACKWARD_LEAPS = "warp.kafka.consumer.backward.leaps";
-  
+
   //
   // ScriptRunner
   //
@@ -1314,12 +1314,12 @@ public class SensisionConstants {
    * Number of messages consumed
    */
   public static final String SENSISION_CLASS_WARP_RUNNER_KAFKA_IN_MESSAGES = "warp.runner.kafka.in.messages";
-  
+
   /**
    * Number of bytes consumed
    */
   public static final String SENSISION_CLASS_WARP_RUNNER_KAFKA_IN_BYTES = "warp.runner.kafka.in.bytes";
-  
+
   /**
    * Number of invalid MACs for messages consumed by 'ScriptRunner'
    */
@@ -1329,7 +1329,7 @@ public class SensisionConstants {
    * Number of invalid AES wrappings for messages consumed by 'ScriptRunner'
    */
   public static final String SENSISION_CLASS_WARP_RUNNER_KAFKA_IN_INVALIDCIPHERS = "warp.runner.kafka.in.invalidciphers";
-  
+
   /**
    * Number of execution attempts which were rejected by the ExecutorService
    */
@@ -1344,7 +1344,7 @@ public class SensisionConstants {
    * Number of regions known by HBaseRegionKeys for the given table
    */
   public static final String SENSISION_CLASS_WARP_HBASE_KNOWNREGIONS = "warp.hbase.knownregions";
-  
+
   /**
    * Number of Producer get from the producer pool
    */
@@ -1359,16 +1359,16 @@ public class SensisionConstants {
    * Number of tasks currently handled by a region server.
    */
   public static final String SENSISION_CLASS_WARP_HBASE_TASKS = "warp.hbase.tasks";
-  
+
   //
   // Labels
   //
-  
+
   /**
    * Id of the producer for which the metric is collected
    */
   public static final String SENSISION_LABEL_PRODUCER = "producer";
-  
+
   /**
    * Name of application for which the metric is collected
    */
@@ -1383,7 +1383,7 @@ public class SensisionConstants {
    * Name of function for which an Einstein metric is collected
    */
   public static final String SENSISION_LABEL_FUNCTION = "function";
-  
+
   /**
    * Name of application consuming data
    */
@@ -1396,9 +1396,9 @@ public class SensisionConstants {
 
   /**
    * Thread id
-   */  
+   */
   public static final String SENSISION_LABEL_THREAD = "thread";
-  
+
   /**
    * CDN POP used to serve the request
    */
@@ -1418,12 +1418,12 @@ public class SensisionConstants {
    * Kafka Partition
    */
   public static final String SENSISION_LABEL_PARTITION = "partition";
-  
+
   /**
    * Kafka Group ID
    */
   public static final String SENSISION_LABEL_GROUPID = "groupid";
-  
+
   /**
    * Name of GeoDirectory
    */
@@ -1438,7 +1438,7 @@ public class SensisionConstants {
    * Id of something
    */
   public static final String SENSISION_LABEL_ID = "id";
-  
+
   /**
    * Component
    */
@@ -1448,15 +1448,20 @@ public class SensisionConstants {
    * Server (usually RegionServer)
    */
   public static final String SENSISION_LABEL_SERVER = "server";
-  
+
   /**
    * Table
    */
   public static final String SENSISION_LABEL_TABLE = "table";
-  
+
+  /**
+   * Label
+   */
+  public static final String SENSISION_LABEL_LABEL = "label";
+
   //
   // TTLs (in ms)
   //
-  
+
   public static final long SENSISION_TTL_PERUSER = 24 * 3600L * 1000L;
 }

--- a/warp10/src/main/java/io/warp10/standalone/StandaloneDirectoryClient.java
+++ b/warp10/src/main/java/io/warp10/standalone/StandaloneDirectoryClient.java
@@ -44,6 +44,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -71,66 +73,81 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.MapMaker;
 
 public class StandaloneDirectoryClient implements DirectoryClient {
-  
+
   private static final Logger LOG = LoggerFactory.getLogger(StandaloneDirectoryClient.class);
-  
+
   private static final String DIRECTORY_INIT_NTHREADS_DEFAULT = "4";
-  
+
   private static final byte[] METADATA_PREFIX = "M".getBytes(Charsets.US_ASCII);
-  
+
   private static final int MAX_BATCH_SIZE = 500000;
-  
+
   private final DB db;
   private final KeyStore keystore;
-  
+
   private final byte[] classKey;
   private final byte[] labelsKey;
-  
+
   private final long[] classLongs;
   private final long[] labelsLongs;
-  
+
   private final byte[] aesKey;
-  
+
   private final int initNThreads;
-  
+
   /**
    * Maps of class name to labelsId to metadata
    */
   // 128BITS
   private static final Map<String,Map<Long,Metadata>> metadatas = new MapMaker().concurrencyLevel(64).makeMap();
   private static final Map<BigInteger,Metadata> metadatasById = new MapMaker().concurrencyLevel(64).makeMap();
-  
+
+  /**
+   * Map of classId to class names
+   */
+  private final Map<Long,String> classNames = new MapMaker().concurrencyLevel(64).makeMap();
+
+  private String splitLabel = Constants.OWNER_LABEL;
+  private final Map<String,Set<String>> splitClasses = new MapMaker().concurrencyLevel(64).makeMap();
+  private final Map<String,String> sensisionSplitLabels = new HashMap<String,String>();
+
   public StandaloneDirectoryClient(DB db, final KeyStore keystore) {
-    
+
     this.initNThreads = Integer.parseInt(WarpConfig.getProperties().getProperty(Configuration.DIRECTORY_INIT_NTHREADS, DIRECTORY_INIT_NTHREADS_DEFAULT));
+
+    if (WarpConfig.getProperties().containsKey(io.warp10.continuum.Configuration.DIRECTORY_SPLIT_LABEL)) {
+      this.splitLabel = WarpConfig.getProperties().getProperty(io.warp10.continuum.Configuration.DIRECTORY_SPLIT_LABEL);
+    }
+
+    this.sensisionSplitLabels.put(SensisionConstants.SENSISION_LABEL_LABEL, this.splitLabel);
 
     this.db = db;
     this.keystore = keystore;
-  
+
     this.aesKey = this.keystore.getKey(KeyStore.AES_LEVELDB_METADATA);
     this.classKey = this.keystore.getKey(KeyStore.SIPHASH_CLASS);
     this.classLongs = SipHashInline.getKey(this.classKey);
-    
+
     this.labelsKey = this.keystore.getKey(KeyStore.SIPHASH_LABELS);
     this.labelsLongs = SipHashInline.getKey(this.labelsKey);
-    
+
     //
     // Read metadata from DB
     //
-    
+
     if (null == db) {
-      return;      
+      return;
     }
-    
+
     DBIterator iter = db.iterator();
-    
+
     iter.seek(METADATA_PREFIX);
 
     byte[] stop = "N".getBytes(Charsets.US_ASCII);
-    
+
     long count = 0;
-    
-    
+
+
     Thread[] initThreads = new Thread[this.initNThreads];
     final AtomicBoolean[] stopMarkers = new AtomicBoolean[this.initNThreads];
     final LinkedBlockingQueue<Entry<byte[],byte[]>> resultQ = new LinkedBlockingQueue<Entry<byte[],byte[]>>(initThreads.length * 8192);
@@ -141,12 +158,12 @@ public class StandaloneDirectoryClient implements DirectoryClient {
       initThreads[i] = new Thread(new Runnable() {
         @Override
         public void run() {
-          
+
           byte[] bytes = new byte[16];
 
           AESWrapEngine engine = null;
           PKCS7Padding padding = null;
-          
+
           if (null != keystore.getKey(KeyStore.AES_LEVELDB_METADATA)) {
             engine = new AESWrapEngine();
             CipherParameters params = new KeyParameter(keystore.getKey(KeyStore.AES_LEVELDB_METADATA));
@@ -154,54 +171,54 @@ public class StandaloneDirectoryClient implements DirectoryClient {
 
             padding = new PKCS7Padding();
           }
-          
+
           TDeserializer deserializer = new TDeserializer(new TCompactProtocol.Factory());
 
           while (!stopMe.get()) {
             try {
-              
+
               Entry<byte[],byte[]> result = resultQ.poll(100, TimeUnit.MILLISECONDS);
-              
+
               if (null == result) {
                 continue;
               }
-              
+
               byte[] key = result.getKey();
               byte[] value = result.getValue();
-              
+
               //
               // Unwrap
               //
-              
+
               byte[] unwrapped = null != engine ? engine.unwrap(value, 0, value.length) : value;
-              
+
               //
               // Unpad
               //
-              
+
               int padcount = null != padding ? padding.padCount(unwrapped) : 0;
               byte[] unpadded = null != padding ? Arrays.copyOf(unwrapped, unwrapped.length - padcount) : unwrapped;
-              
+
               //
               // Deserialize
               //
 
               Metadata metadata = new Metadata();
               deserializer.deserialize(metadata, unpadded);
-              
+
               //
               // Compute classId/labelsId and compare it to the values in the row key
               //
-              
+
               // 128BITS
               long classId = GTSHelper.classId(classLongs, metadata.getName());
               long labelsId = GTSHelper.labelsId(labelsLongs, metadata.getLabels());
-              
+
               ByteBuffer bb = ByteBuffer.wrap(key).order(ByteOrder.BIG_ENDIAN);
               bb.position(1);
               long hbClassId = bb.getLong();
               long hbLabelsId = bb.getLong();
-              
+
               // If classId/labelsId are incoherent, skip metadata
               if (classId != hbClassId || labelsId != hbLabelsId) {
                 // FIXME(hbs): LOG
@@ -212,27 +229,49 @@ public class StandaloneDirectoryClient implements DirectoryClient {
               // 128BITS
               metadata.setClassId(classId);
               metadata.setLabelsId(labelsId);
-              
+
               if (!metadata.isSetAttributes()) {
                 metadata.setAttributes(new HashMap<String,String>());
               }
-              
+
               //
               // Internalize Strings
               //
-              
+
               GTSHelper.internalizeStrings(metadata);
 
               synchronized(metadatas) {
                 if (!metadatas.containsKey(metadata.getName())) {
                   metadatas.put(metadata.getName(), (Map) new MapMaker().concurrencyLevel(64).makeMap());
-                }                
+                  classNames.put(classId, metadata.getName());
+                }
               }
-              
+
+              //
+              // Store per label class name. We use the name since it has been internalized,
+              // therefore we only consume the HashNode and the HashSet overhead
+              //
+
+              String label = metadata.getLabels().get(splitLabel);
+              if (null != label) {
+                synchronized(splitClasses) {
+                  Set<String> classes = splitClasses.get(label);
+
+                  if (null == classes) {
+                    classes = new ConcurrentSkipListSet<String>();
+                    splitClasses.put(label, classes);
+                  }
+
+                  classes.add(metadata.getName());
+                }
+
+                Sensision.set(SensisionConstants.SENSISION_CLASS_CONTINUUM_DIRECTORY_SPLITS, sensisionSplitLabels, splitClasses.size());
+              }
+
               synchronized(metadatas.get(metadata.getName())) {
                 if (!metadatas.get(metadata.getName()).containsKey(labelsId)) {
                   metadatas.get(metadata.getName()).put(labelsId, metadata);
-                  
+
                   //
                   // Store Metadata under 'id'
                   //
@@ -244,41 +283,41 @@ public class StandaloneDirectoryClient implements DirectoryClient {
                   continue;
                 }
               }
-              
+
               // FIXME(hbs): LOG
               System.err.println("Duplicate labelsId for classId " + classId + ": " + metadata);
               continue;
-              
+
             } catch (InvalidCipherTextException icte) {
               throw new RuntimeException(icte);
             } catch (TException te) {
               throw new RuntimeException(te);
             } catch (InterruptedException ie) {
-              
+
             }
-            
+
           }
         }
       });
-      
+
       initThreads[i].setDaemon(true);
       initThreads[i].setName("[Directory initializer #" + i + "]");
       initThreads[i].start();
     }
-    
+
     try {
-      
+
       long nano = System.nanoTime();
-      
+
       while(iter.hasNext()) {
         Entry<byte[],byte[]> kv = iter.next();
         byte[] key = kv.getKey();
         if (Bytes.compareTo(key, stop) >= 0) {
           break;
         }
-                                
+
         boolean interrupted = true;
-        
+
         while(interrupted) {
           interrupted = false;
           try {
@@ -291,26 +330,26 @@ public class StandaloneDirectoryClient implements DirectoryClient {
             interrupted = true;
           }
         }
-      }      
-      
+      }
+
       //
       // Wait until resultQ is empty
       //
-      
+
       while(!resultQ.isEmpty()) {
         try { Thread.sleep(100L); } catch (InterruptedException ie) {}
       }
-      
+
       //
       // Notify the init threads to stop
       //
-      
+
       for (int i = 0; i < initNThreads; i++) {
         stopMarkers[i].set(true);
       }
-      
+
       nano = System.nanoTime() - nano;
-      
+
       System.out.println("Loaded " + count + " GTS in " + (nano / 1000000.0D) + " ms");
     } finally {
       Sensision.set(SensisionConstants.SENSISION_CLASS_CONTINUUM_DIRECTORY_GTS, Sensision.EMPTY_LABELS, count);
@@ -321,75 +360,88 @@ public class StandaloneDirectoryClient implements DirectoryClient {
       }
     }
   }
-  
+
   public List<Metadata> find(List<String> classExpr, List<Map<String,String>> labelsExpr) {
-    
+
     //
     // Build patterns from expressions
     //
-    
+
     SmartPattern classSmartPattern;
-    
+
     Collection<Metadata> metadatas;
-    
+
     if (classExpr.size() > 1) {
       metadatas = new HashSet<Metadata>();
     } else {
       metadatas = new ArrayList<Metadata>();
     }
 
-    Set<String> classNames = null;
-    
     for (int i = 0; i < classExpr.size(); i++) {
-      
+
       String exactClassName = null;
-      
+
       if (classExpr.get(i).startsWith("=") || !classExpr.get(i).startsWith("~")) {
         exactClassName = classExpr.get(i).startsWith("=") ? classExpr.get(i).substring(1) : classExpr.get(i);
         classSmartPattern = new SmartPattern(exactClassName);
       } else {
         classSmartPattern = new SmartPattern(Pattern.compile(classExpr.get(i).substring(1)));
       }
-      
+
       Map<String,SmartPattern> labelPatterns = new HashMap<String,SmartPattern>();
-      
+
       if (null != labelsExpr.get(i)) {
         for (Entry<String,String> entry: labelsExpr.get(i).entrySet()) {
           String label = entry.getKey();
           String expr = entry.getValue();
           Pattern pattern;
-          
+
           if (expr.startsWith("=") || !expr.startsWith("~")) {
             labelPatterns.put(label, new SmartPattern(expr.startsWith("=") ? expr.substring(1) : expr));
           } else {
             pattern = Pattern.compile(expr.substring(1));
             labelPatterns.put(label,  new SmartPattern(pattern));
-          }          
-        }      
+          }
+        }
       }
-             
+
+      // Copy the class names as 'this.classNames' might be updated while in the for loop
+      Collection<String> classNames = new ArrayList<String>();
+
       if (null != exactClassName) {
         if (!this.metadatas.containsKey(exactClassName)) {
           continue;
         }
-        classNames = new HashSet<String>();
         classNames.add(exactClassName);
       } else {
-        classNames = this.metadatas.keySet();
+        //
+        // Extract per label classes if label selector exists
+        //
+        if (null != labelsExpr.get(i)) {
+          String labelsel = labelsExpr.get(i).get(splitLabel);
+
+          if (null != labelsel && labelsel.startsWith("=")) {
+            classNames = splitClasses.get(labelsel.substring(1));
+          } else {
+            classNames = this.classNames.values();
+          }
+        } else {
+          classNames = this.classNames.values();
+        }
       }
 
       //
       // Create arrays to check the labels, this is to speed up discard
       //
-      
+
       List<String> labelNames = new ArrayList<String>(labelPatterns.size());
       List<SmartPattern> labelSmartPatterns = new ArrayList<SmartPattern>(labelPatterns.size());
       String[] labelValues = null;
-      
+
       //
       // Put producer/app/owner first
       //
-      
+
       if (labelPatterns.containsKey(Constants.PRODUCER_LABEL)) {
         labelNames.add(Constants.PRODUCER_LABEL);
         labelSmartPatterns.add(labelPatterns.get(Constants.PRODUCER_LABEL));
@@ -405,11 +457,11 @@ public class StandaloneDirectoryClient implements DirectoryClient {
         labelSmartPatterns.add(labelPatterns.get(Constants.OWNER_LABEL));
         labelPatterns.remove(Constants.OWNER_LABEL);
       }
-      
+
       //
       // Now add the other labels
       //
-      
+
       for(Entry<String,SmartPattern> entry: labelPatterns.entrySet()) {
         labelNames.add(entry.getKey());
         labelSmartPatterns.add(entry.getValue());
@@ -420,19 +472,19 @@ public class StandaloneDirectoryClient implements DirectoryClient {
       //
       // Loop over the class names to find matches
       //
-      
+
       for (String className: classNames) {
-                
+
         //
         // If class matches, check all labels for matches
         //
-        
+
         if (classSmartPattern.matches(className)) {
           for (Metadata metadata: this.metadatas.get(className).values()) {
             boolean exclude = false;
-            
+
             int idx = 0;
-      
+
             for (String labelName: labelNames) {
               //
               // Immediately exclude metadata which do not contain one of the
@@ -440,7 +492,7 @@ public class StandaloneDirectoryClient implements DirectoryClient {
               //
 
               String labelValue = metadata.getLabels().get(labelName);
-              
+
               if (null == labelValue) {
                 labelValue = metadata.getAttributes().get(labelName);
                 if (null == labelValue) {
@@ -448,40 +500,40 @@ public class StandaloneDirectoryClient implements DirectoryClient {
                   break;
                 }
               }
-              
+
               labelValues[idx++] = labelValue;
             }
-            
+
             // If we did not collect enough label/attribute values, exclude the GTS
             if (idx < labelNames.size()) {
               exclude = true;
             }
-            
+
             if (exclude) {
               continue;
             }
-            
+
             //
             // Check if the label value matches, if not, exclude the GTS
             //
-            
+
             for (int j = 0; j < labelNames.size(); j++) {
               if (!labelSmartPatterns.get(j).matches(labelValues[j])) {
                 exclude = true;
                 break;
               }
             }
-            
+
             if (exclude) {
               continue;
             }
-            
+
             //
             // We have a match, rebuild metadata
             //
             // FIXME(hbs): include a 'safe' mode to expose the internal Metadata instances?
             //
-            
+
             Metadata meta = new Metadata();
             meta.setName(className);
             meta.setLabels(ImmutableMap.copyOf(metadata.getLabels()));
@@ -497,44 +549,44 @@ public class StandaloneDirectoryClient implements DirectoryClient {
             } else {
               meta.setLabelsId(GTSHelper.labelsId(labelsKey, meta.getLabels()));
             }
-            
+
             metadatas.add(meta);
           }
         }
-      }      
+      }
     }
-    
+
     if (classExpr.size() > 1) {
       List<Metadata> metas = new ArrayList<Metadata>();
       metas.addAll(metadatas);
       return metas;
     } else {
       return (List<Metadata>) metadatas;
-    }    
+    }
   };
-  
+
   public void register(Metadata metadata) throws IOException {
-    
+
     //
     // Special case of null means flush leveldb
     //
-    
+
     if (null == metadata) {
       store(null, null);
       return;
     }
-    
+
     //
     // If the metadata are not known, register them
     //
-        
+
     if (Configuration.INGRESS_METADATA_SOURCE.equals(metadata.getSource()) && !metadatas.containsKey(metadata.getName())) {
       store(metadata);
     } else if (Configuration.INGRESS_METADATA_SOURCE.equals(metadata.getSource())) {
       // Compute labelsId
       // 128BITS
       long labelsId = GTSHelper.labelsId(this.labelsLongs, metadata.getLabels());
-      
+
       if (!metadatas.get(metadata.getName()).containsKey(labelsId)) {
         store(metadata);
       } else if (!metadatas.get(metadata.getName()).get(labelsId).getLabels().equals(metadata.getLabels())) {
@@ -545,7 +597,7 @@ public class StandaloneDirectoryClient implements DirectoryClient {
       //
       // Metadata registration is not from Ingress, this means we can update the value as it comes from the directory service or a metadata update
       //
-      
+
       // When it is a metadata update request, only store the metadata if the GTS is already known
       if (Configuration.INGRESS_METADATA_UPDATE_ENDPOINT.equals(metadata.getSource())) {
         if (metadatas.containsKey(metadata.getName())) {
@@ -560,7 +612,7 @@ public class StandaloneDirectoryClient implements DirectoryClient {
       }
     }
   }
-  
+
   public synchronized void unregister(Metadata metadata) {
     if (!metadatas.containsKey(metadata.getName())) {
       return;
@@ -573,6 +625,7 @@ public class StandaloneDirectoryClient implements DirectoryClient {
     metadatas.get(metadata.getName()).remove(labelsId);
     if (metadatas.get(metadata.getName()).isEmpty()) {
       metadatas.remove(metadata.getName());
+      classNames.remove(metadata.getClassId());
     }
 
     // 128BITS
@@ -582,11 +635,11 @@ public class StandaloneDirectoryClient implements DirectoryClient {
     byte[] idbytes = new byte[16];
     GTSHelper.fillGTSIds(idbytes, 0, classId, labelsId);
     this.metadatasById.remove(new BigInteger(idbytes));
-    
+
     //
     // Remove entry from DB if need be
     //
-    
+
     if (null == this.db) {
       Sensision.update(SensisionConstants.SENSISION_CLASS_CONTINUUM_DIRECTORY_GTS, Sensision.EMPTY_LABELS, -1);
       return;
@@ -595,9 +648,9 @@ public class StandaloneDirectoryClient implements DirectoryClient {
 
     byte[] bytes = new byte[1 + 8 + 8];
     System.arraycopy(METADATA_PREFIX, 0, bytes, 0, METADATA_PREFIX.length);
-    
+
     int idx = METADATA_PREFIX.length;
-    
+
     bytes[idx++] = (byte) ((classId >> 56) & 0xff);
     bytes[idx++] = (byte) ((classId >> 48) & 0xff);
     bytes[idx++] = (byte) ((classId >> 40) & 0xff);
@@ -617,16 +670,16 @@ public class StandaloneDirectoryClient implements DirectoryClient {
     bytes[idx++] = (byte) (labelsId & 0xff);
 
     this.db.delete(bytes);
-    
+
     Sensision.update(SensisionConstants.SENSISION_CLASS_CONTINUUM_DIRECTORY_GTS, Sensision.EMPTY_LABELS, -1);
   }
-  
+
   private ThreadLocal<WriteBatch> perThreadWriteBatch = new ThreadLocal<WriteBatch>() {
-    protected WriteBatch initialValue() {      
+    protected WriteBatch initialValue() {
       return db.createWriteBatch();
-    };    
+    };
   };
-  
+
   private ThreadLocal<AtomicLong> perThreadWriteBatchSize = new ThreadLocal<AtomicLong>() {
     protected AtomicLong initialValue() {
       return new AtomicLong(0L);
@@ -634,23 +687,23 @@ public class StandaloneDirectoryClient implements DirectoryClient {
   };
 
   private void store(byte[] key, byte[] value) throws IOException {
-    
+
     if (null == this.db) {
       return;
     }
-    
+
     WriteBatch batch = perThreadWriteBatch.get();
 
     AtomicLong size = perThreadWriteBatchSize.get();
-    
+
     boolean written = false;
-    
+
     try {
       if (null != key && null != value) {
         batch.put(key, value);
         size.addAndGet(key.length + value.length);
       }
-      
+
       if (null == key || null == value || size.get() > MAX_BATCH_SIZE) {
         this.db.write(batch);
         size.set(0L);
@@ -661,25 +714,25 @@ public class StandaloneDirectoryClient implements DirectoryClient {
       if (written) {
         batch.close();
       }
-    }    
+    }
   }
-  
+
   private void store(Metadata metadata) throws IOException {
     // Compute labelsId and classId
     // 128BITS
     long classId = GTSHelper.classId(this.classLongs, metadata.getName());
     long labelsId = GTSHelper.labelsId(this.labelsLongs, metadata.getLabels());
-    
-    //ByteBuffer bb = ByteBuffer.wrap(new byte[1 + 8 + 8]).order(ByteOrder.BIG_ENDIAN);    
+
+    //ByteBuffer bb = ByteBuffer.wrap(new byte[1 + 8 + 8]).order(ByteOrder.BIG_ENDIAN);
     //bb.put(METADATA_PREFIX);
     //bb.putLong(classId);
     //bb.putLong(labelsId);
 
     byte[] bytes = new byte[1 + 8 + 8];
     System.arraycopy(METADATA_PREFIX, 0, bytes, 0, METADATA_PREFIX.length);
-    
+
     int idx = METADATA_PREFIX.length;
-    
+
     bytes[idx++] = (byte) ((classId >> 56) & 0xff);
     bytes[idx++] = (byte) ((classId >> 48) & 0xff);
     bytes[idx++] = (byte) ((classId >> 40) & 0xff);
@@ -700,20 +753,20 @@ public class StandaloneDirectoryClient implements DirectoryClient {
 
     metadata.setClassId(classId);
     metadata.setLabelsId(labelsId);
-    
+
     if (null == metadata.getAttributes()) {
       metadata.setAttributes(new HashMap<String,String>());
     }
-    
+
     TSerializer serializer = new TSerializer(new TCompactProtocol.Factory());
-    
+
     try {
       if (null != this.db) {
         byte[] serialized = serializer.serialize(metadata);
         if (null != this.aesKey) {
           serialized = CryptoUtils.wrap(this.aesKey, serialized);
         }
-        
+
         //this.db.put(bb.array(), serialized);
         //this.db.put(bytes, serialized);
         store(bytes, serialized);
@@ -721,15 +774,37 @@ public class StandaloneDirectoryClient implements DirectoryClient {
       synchronized (metadatas) {
         if (!metadatas.containsKey(metadata.getName())) {
           metadatas.put(metadata.getName(), (Map) new MapMaker().concurrencyLevel(64).makeMap());
+          classNames.put(classId, metadata.getName());
         }
         if (null == metadatas.get(metadata.getName()).put(labelsId, metadata)) {
           Sensision.update(SensisionConstants.SENSISION_CLASS_CONTINUUM_DIRECTORY_GTS, Sensision.EMPTY_LABELS, 1);
         }
       }
+
+      //
+      // Store per label class name. We use the name since it has been internalized,
+      // therefore we only consume the HashNode and the HashSet overhead
+      //
+      String label = metadata.getLabels().get(splitLabel);
+      if (null != label) {
+        synchronized(splitClasses) {
+          Set<String> classes = splitClasses.get(label);
+
+          if (null == classes) {
+            classes = new ConcurrentSkipListSet<String>();
+            splitClasses.put(label, classes);
+          }
+
+          classes.add(metadata.getName());
+        }
+
+        Sensision.set(SensisionConstants.SENSISION_CLASS_CONTINUUM_DIRECTORY_SPLITS, sensisionSplitLabels, splitClasses.size());
+      }
+
       //
       // Store Metadata under 'id'
       //
-      
+
       byte[] idbytes = new byte[16];
       GTSHelper.fillGTSIds(idbytes, 0, classId, labelsId);
       BigInteger id = new BigInteger(idbytes);
@@ -739,16 +814,16 @@ public class StandaloneDirectoryClient implements DirectoryClient {
       throw new RuntimeException(te);
     }
   }
-  
+
   public Metadata getMetadataById(BigInteger id) {
     return this.metadatasById.get(id);
   }
-  
+
   @Override
   public Map<String,Object> stats(List<String> classSelector, List<Map<String, String>> labelsSelectors) throws IOException {
     throw new IOException("stats is not available in standalone mode.");
   }
-  
+
   @Override
   public MetadataIterator iterator(List<String> classSelector, List<Map<String, String>> labelsSelectors) throws IOException {
     List<Metadata> metadatas = find(classSelector, labelsSelectors);
@@ -758,10 +833,10 @@ public class StandaloneDirectoryClient implements DirectoryClient {
     return new MetadataIterator() {
       @Override
       public void close() throws Exception {}
-      
+
       @Override
       public boolean hasNext() { return iter.hasNext(); }
-      
+
       @Override
       public Metadata next() { return iter.next(); }
     };


### PR DESCRIPTION
Directory split classnames by `.owner` label. This work well on multi-tenant instance but is useless on instance with only one producer.

This PR add a configuration to choose on which label perform the split.