### PR TITLE
Fixes #180 - Set a more meaningful class name in REDUCE

### DIFF
--- a/warp10/src/main/java/io/warp10/continuum/gts/GTSHelper.java
+++ b/warp10/src/main/java/io/warp10/continuum/gts/GTSHelper.java
@@ -5374,16 +5374,27 @@ public class GTSHelper {
         result = new GeoTimeSerie();
       }
 
-      result.setName("");
       result.setLabels(partitionLabels);
-      
+
+      String name = null;
+
       //
       // Sort all series in the partition so we can scan their ticks in order
+      // Checking if classname is identical between GTS. If so, using it
       //
         
       for (GeoTimeSerie gts: partitionSeries) {
         sort(gts, false);
+
+        if (null == name){
+          name = gts.getName();
+        } else if (!gts.getName().equals(name) && name.length() != 0) {
+          name = "";
+        }
       }
+
+      result.setName(name);
+
       
       Map<String,GeoTimeSerie> multipleResults = new TreeMap<String,GeoTimeSerie>();
       


### PR DESCRIPTION
This PR is fixing [Issues 180](https://github.com/cityzendata/warp10-platform/issues/180). Now during REDUCE, classname is retained if identical across all GTS.