### PR TITLE
Add support for consumerid in Kafka ConsumerConnector

### DIFF
--- a/etc/conf-distributed.template
+++ b/etc/conf-distributed.template
@@ -1046,6 +1046,11 @@ store.hbase.hconnection.threads.core = 4
 #store.kafka.data.consumer.clientid = 
 
 //
+// A prefix prepended to the Kafka ConsumerId
+//
+#store.kafka.data.consumerid.prefix =
+
+//
 // Custom value of 'hbase.client.ipc.pool.size' for the Store HBase pool
 //
 #store.hbase.client.ipc.pool.size = 

--- a/warp10/src/main/java/io/warp10/continuum/Configuration.java
+++ b/warp10/src/main/java/io/warp10/continuum/Configuration.java
@@ -795,6 +795,11 @@ public class Configuration {
   public static final String STORE_KAFKA_DATA_GROUPID = "store.kafka.data.groupid";
 
   /**
+   * A prefix prepended to the Kafka ConsumerId
+   */
+  public static final String STORE_KAFKA_DATA_CONSUMERID_PREFIX = "store.kafka.data.consumerid.prefix";
+
+  /**
    * Client id to use to consume the data topic
    */
   public static final String STORE_KAFKA_DATA_CONSUMER_CLIENTID = "store.kafka.data.consumer.clientid";

--- a/warp10/src/main/java/io/warp10/continuum/store/Store.java
+++ b/warp10/src/main/java/io/warp10/continuum/store/Store.java
@@ -28,6 +28,8 @@ import io.warp10.crypto.CryptoUtils;
 import io.warp10.crypto.KeyStore;
 import io.warp10.sensision.Sensision;
 
+import java.net.InetAddress;
+import java.util.UUID;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
@@ -318,7 +320,7 @@ public class Store extends Thread {
     }
     
     maxPendingPutsSize = Long.parseLong(properties.getProperty(io.warp10.continuum.Configuration.STORE_HBASE_DATA_MAXPENDINGPUTSSIZE));
-    
+
     final String groupid = properties.getProperty(io.warp10.continuum.Configuration.STORE_KAFKA_DATA_GROUPID);
 
     final KafkaOffsetCounters counters = new KafkaOffsetCounters(topic, groupid, commitPeriod * 2);
@@ -359,6 +361,16 @@ public class Store extends Thread {
             props.setProperty("group.id", groupid);
             if (null != properties.getProperty(io.warp10.continuum.Configuration.STORE_KAFKA_DATA_CONSUMER_CLIENTID)) {
               props.setProperty("client.id", properties.getProperty(io.warp10.continuum.Configuration.STORE_KAFKA_DATA_CONSUMER_CLIENTID));
+            }
+            if (null != properties.getProperty(io.warp10.continuum.Configuration.STORE_KAFKA_DATA_CONSUMERID_PREFIX)) {
+              // If a consumerId prefix is provided, the consumerId is built the same way than inside the Kafka ConsumerConnector with the prefix part prepended to the hostname
+              UUID uuid = UUID.randomUUID();
+              String consumerUuid = String.format("%s_%s_%d-%s",
+                      properties.getProperty(io.warp10.continuum.Configuration.STORE_KAFKA_DATA_CONSUMERID_PREFIX),
+                      InetAddress.getLocalHost().getHostName(),
+                      System.currentTimeMillis(),
+                      Long.toHexString(uuid.getMostSignificantBits()).substring(0,8));
+              props.setProperty("consumer.id", consumerUuid);
             }
             if (null != properties.getProperty(io.warp10.continuum.Configuration.STORE_KAFKA_DATA_CONSUMER_PARTITION_ASSIGNMENT_STRATEGY)) {
               props.setProperty("partition.assignment.strategy", properties.getProperty(io.warp10.continuum.Configuration.STORE_KAFKA_DATA_CONSUMER_PARTITION_ASSIGNMENT_STRATEGY));


### PR DESCRIPTION
Add support for consumerid infix in Kafka ConsumerConnector to identify consumer instances running on the same host