### PR TITLE
Fixed conversion issue on TOLONG when there is a leading zero

### DIFF
--- a/warp10/src/main/java/io/warp10/script/unary/TOLONG.java
+++ b/warp10/src/main/java/io/warp10/script/unary/TOLONG.java
@@ -43,7 +43,7 @@ public class TOLONG extends NamedWarpScriptFunction implements WarpScriptStackFu
         stack.push(0L);
       }
     } else if (op instanceof String) {
-      stack.push(Long.decode(op.toString()));
+      stack.push(Long.valueOf(op.toString()));
     } else {
       throw new WarpScriptException(getName() + " can only operate on numeric, boolean or string values.");
     }


### PR DESCRIPTION
Currently, using TOLONG on a string with a leading zero is throwing [errors or the wrong number](https://home.cityzendata.net/quantum/#/warpscript/JzA2JyBUT0xPTkcKJzA3JyBUT0xPTkcKJzAxNycgVE9MT05HIC8vIHB1c2hpbmcgMTUgaW4gdGhlIHN0YWNrCicwOCcgVE9MT05HIC8vIG5vdCB3b3JraW5nCg%3D%3D/eyJ1cmwiOiJodHRwczovL3dhcnAuY2l0eXplbmRhdGEubmV0L2FwaS92MCIsImZldGNoRW5kcG9pbnQiOiIvZmV0Y2giLCJoZWFkZXJOYW1lIjoiWC1XYXJwMTAifQ%3D%3D) on some cases.