### PR TITLE
Add new metric when an estimator is reset 

### DIFF
--- a/warp10/src/main/java/io/warp10/continuum/ThrottlingManager.java
+++ b/warp10/src/main/java/io/warp10/continuum/ThrottlingManager.java
@@ -794,8 +794,8 @@ public class ThrottlingManager {
                       applicationHLLPEstimators.remove(entity);
                       Map<String,String> labels = new HashMap<String, String>();
                       labels.put(SensisionConstants.SENSISION_LABEL_APPLICATION, entity);
-                      Sensision.clear(SensisionConstants.SENSISION_CLASS_CONTINUUM_GTS_DISTINCT, labels);
-                      Sensision.event(SensisionConstants.SENSISION_CLASS_CONTINUUM_GTS_DISTINCT, labels, 0);              
+                      Sensision.clear(SensisionConstants.SENSISION_CLASS_CONTINUUM_GTS_DISTINCT_PER_APP, labels);
+                      Sensision.event(SensisionConstants.SENSISION_CLASS_CONTINUUM_GTS_DISTINCT_PER_APP, labels, 0);
                     }
                   }
                 } else if (!"".equals(estimator)) {                  

--- a/warp10/src/main/java/io/warp10/continuum/ThrottlingManager.java
+++ b/warp10/src/main/java/io/warp10/continuum/ThrottlingManager.java
@@ -788,6 +788,7 @@ public class ThrottlingManager {
                       labels.put(SensisionConstants.SENSISION_LABEL_PRODUCER, entity);
                       Sensision.clear(SensisionConstants.SENSISION_CLASS_CONTINUUM_GTS_DISTINCT, labels);
                       Sensision.event(SensisionConstants.SENSISION_CLASS_CONTINUUM_GTS_DISTINCT, labels, 0);
+                      Sensision.update(SensisionConstants.SENSISION_CLASS_CONTINUUM_ESTIMATOR_RESETS, labels, 1);
                     }
                   } else {
                     synchronized(applicationHLLPEstimators) {
@@ -796,6 +797,7 @@ public class ThrottlingManager {
                       labels.put(SensisionConstants.SENSISION_LABEL_APPLICATION, entity);
                       Sensision.clear(SensisionConstants.SENSISION_CLASS_CONTINUUM_GTS_DISTINCT_PER_APP, labels);
                       Sensision.event(SensisionConstants.SENSISION_CLASS_CONTINUUM_GTS_DISTINCT_PER_APP, labels, 0);
+                      Sensision.update(SensisionConstants.SENSISION_CLASS_CONTINUUM_ESTIMATOR_RESETS_PER_APP, labels, 1);
                     }
                   }
                 } else if (!"".equals(estimator)) {                  

--- a/warp10/src/main/java/io/warp10/continuum/sensision/SensisionConstants.java
+++ b/warp10/src/main/java/io/warp10/continuum/sensision/SensisionConstants.java
@@ -1026,6 +1026,16 @@ public class SensisionConstants {
   public static final String SENSISION_CLASS_CONTINUUM_ESTIMATORS_CACHED_PER_APP = "warp.estimators.cached.perapp";
 
   /**
+   * Number of times an estimator was reset
+   */
+  public static final String SENSISION_CLASS_CONTINUUM_ESTIMATOR_RESETS = "warp.estimator.resets";
+
+  /**
+   * Number of times an estimator was reset per app
+   */
+  public static final String SENSISION_CLASS_CONTINUUM_ESTIMATOR_RESETS_PER_APP = "warp.estimator.resets.perapp";
+
+  /**
    * Number of invalid hashes detected when 
    */
   public static final String SENSISION_CLASS_PLASMA_BACKEND_SUBSCRIPTIONS_INVALID_HASHES = "warp.plasma.backend.subscriptions.invalid.hashes";


### PR DESCRIPTION
This PR is adding a new metric called *warp.estimators.resets*. Thanks to it, Warp10 administrators can keep track of estimators resets per producer and per app. 

This is also fixing a bad metric name when resetting a per-app estimator.