### PR TITLE
Fixed MAXRECURSION long/int casts.

### DIFF
--- a/warp10/src/main/java/io/warp10/script/functions/MAXRECURSION.java
+++ b/warp10/src/main/java/io/warp10/script/functions/MAXRECURSION.java
@@ -45,11 +45,11 @@ public class MAXRECURSION extends NamedWarpScriptFunction implements WarpScriptS
     
     long limit = ((Number) top).longValue();
 
-    if (limit > (long) stack.getAttribute(WarpScriptStack.ATTRIBUTE_RECURSION_MAXDEPTH_HARD)) {
+    if (limit > (int) stack.getAttribute(WarpScriptStack.ATTRIBUTE_RECURSION_MAXDEPTH_HARD)) {
       throw new WarpScriptException(getName() + " cannot extend limit past " + stack.getAttribute(WarpScriptStack.ATTRIBUTE_RECURSION_MAXDEPTH_HARD));
     }
 
-    stack.setAttribute(WarpScriptStack.ATTRIBUTE_RECURSION_MAXDEPTH, limit);
+    stack.setAttribute(WarpScriptStack.ATTRIBUTE_RECURSION_MAXDEPTH, (int) limit);
     
     return stack;
   }


### PR DESCRIPTION
MAXRECURSION could not be used because of incorrect/missing casts, fixed that by forcing casts to int.
Same issue as https://github.com/cityzendata/warp10-platform/issues/21