### PR TITLE
Added type check on SPLIT.

### DIFF
--- a/warp10/src/main/java/io/warp10/script/functions/SPLIT.java
+++ b/warp10/src/main/java/io/warp10/script/functions/SPLIT.java
@@ -50,7 +50,12 @@ public class SPLIT extends NamedWarpScriptFunction implements WarpScriptStackFun
     char delimiter = o.toString().charAt(0);
     
     o = stack.pop();
-    
+
+    if (!(o instanceof String)) {
+      throw new WarpScriptException(getName() + " operates on a String.");
+    }
+
+
     String[] tokens = UnsafeString.split(o.toString(), delimiter);
     
     List<String> ltokens = new ArrayList<String>();


### PR DESCRIPTION
SPLIT didn't do any type check. So it runs seamlessly on a SET, on a LIST, a MAP.
e.g. results on lists include the [ or ] characters in the results, leading to really strang results.