### PR TITLE
RTFM now pointing to exact function documentation

### DIFF
--- a/warp10/src/main/java/io/warp10/continuum/store/Constants.java
+++ b/warp10/src/main/java/io/warp10/continuum/store/Constants.java
@@ -357,9 +357,10 @@ public class Constants {
   
   public static final String DEFAULT_PACKED_CLASS_SUFFIX = ":packed";
   public static final int DEFAULT_PACKED_MAXSIZE = 65536;
-  
+
   public static final String WARP10_DOC_URL = "http://www.warp10.io/";
-  
+  public static final String WARP10_FUNCTION_DOC_URL = "http://www.warp10.io/doc/";
+
   public static final int WARP_PLASMA_MAXSUBS_DEFAULT = 256000;
   
   public static final String KEY_MODULUS = "modulus";

--- a/warp10/src/main/java/io/warp10/script/functions/RTFM.java
+++ b/warp10/src/main/java/io/warp10/script/functions/RTFM.java
@@ -21,6 +21,11 @@ import io.warp10.script.NamedWarpScriptFunction;
 import io.warp10.script.WarpScriptStackFunction;
 import io.warp10.script.WarpScriptException;
 import io.warp10.script.WarpScriptStack;
+import io.warp10.script.WarpScriptLib;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import io.warp10.crypto.OrderPreservingBase64;
+import com.google.common.base.Charsets;
 
 public class RTFM extends NamedWarpScriptFunction implements WarpScriptStackFunction {
   
@@ -30,7 +35,50 @@ public class RTFM extends NamedWarpScriptFunction implements WarpScriptStackFunc
   
   @Override
   public Object apply(WarpScriptStack stack) throws WarpScriptException {
-    stack.push(Constants.WARP10_DOC_URL);
+    String functionname=null;
+
+    //
+    // if there is a string on the top of the stack, take is as a function name
+    // if the function name is valid, returns the help URL.
+    //
+    // RTFM do not pop the string anyway.
+    //
+
+    if (0 < stack.depth()) {
+      Object o = stack.peek();
+      if (o instanceof String) {
+        functionname = o.toString();
+        if (!WarpScriptLib.getFunctionNames().contains(functionname)) {
+          functionname="";
+        }
+      }
+    }
+
+    if (null == functionname) {
+      stack.push(Constants.WARP10_DOC_URL);
+    }
+    else if ( "" == functionname) {
+      stack.push("Unknown function name, please check " + Constants.WARP10_DOC_URL);
+    }
+    else {
+      String forbiddenindoc = ".*[!%&\\(\\)\\*+/<=>\\[\\]^\\{\\|\\}~].*";
+      Pattern pattern = Pattern.compile(forbiddenindoc);
+      String docname = functionname;
+      Matcher m = pattern.matcher(functionname);
+      if (m.matches()
+          || "-".equals(functionname)
+          || "pi".equals(functionname)
+          || "PI".equals(functionname)
+          || "e".equals(functionname)
+          || "E".equals(functionname)
+          || "Pfilter".equals(functionname)
+          ) {
+        //contains forbidden characters, or is a name exception.
+        docname = new String(OrderPreservingBase64.encode(functionname.getBytes(Charsets.UTF_8)), Charsets.UTF_8);
+      }
+      stack.push(Constants.WARP10_FUNCTION_DOC_URL + docname);
+    }
+
     return stack;
   }
 }


### PR DESCRIPTION
Ready for next doc release. WARP10_FUNCTION_DOC_URL may evolve in the meantime.

RTFM  //returns "http://www.warp10.io/" (empty stack)
54 RTFM //returns "http://www.warp10.io/" (no string on top)
'BINOUZE' RTFM //returns "Unknown function name, please check http://www.warp10.io/"
'DROP' RTFM //returns "http://www.warp10.io/doc/DROP"
'**' RTFM  //returns "http://www.warp10.io/doc/9Xc"