### PR TITLE
Fix the RGB color management in processing functions

### DIFF
--- a/warp10/src/main/java/io/warp10/script/processing/color/PcolorMode.java
+++ b/warp10/src/main/java/io/warp10/script/processing/color/PcolorMode.java
@@ -49,7 +49,7 @@ public class PcolorMode extends NamedWarpScriptFunction implements WarpScriptSta
       throw new WarpScriptException(getName() + ": invalid mode, should be one of 'RGB' or 'HSB'");      
     }
     
-    int mode = "RGB".equals(modestr) ? PGraphics.ARGB : PGraphics.HSB;
+    int mode = "RGB".equals(modestr) ? PGraphics.RGB : PGraphics.HSB;
     
     if (2 == params.size()) {
       pg.colorMode(mode);

--- a/warp10/src/main/java/io/warp10/script/processing/rendering/PGraphics.java
+++ b/warp10/src/main/java/io/warp10/script/processing/rendering/PGraphics.java
@@ -95,7 +95,7 @@ public class PGraphics extends NamedWarpScriptFunction implements WarpScriptStac
     pg.beginDraw();
  
     pg.loadPixels();
-    pg.colorMode(pg.ARGB, 255, 255, 255, 255);
+    pg.colorMode(pg.RGB, 255, 255, 255, 255);
 
     stack.push(pg);
     


### PR DESCRIPTION
By default, ARGB was defined. But in processing, ARGB is not managed by
colorCalc function.

    switch (colorMode) {
    case RGB:
	... (also manage alpha)
    case HSB:
	...

colorCalc is called by every functions which takes a color as input. So,
all signatures were broken for these functions : only grayscale and
direct ARGB long produce the expected result.
